### PR TITLE
feat: support `OPENCLAW_PROFILE` env var for multi-profile setups

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -572,15 +572,17 @@ function getSystemVitals() {
 
 // Helper to run openclaw commands
 function runOpenClaw(args) {
+  const profile = process.env.OPENCLAW_PROFILE || "";
+  const profileFlag = profile ? ` --profile ${profile}` : "";
   try {
-    const result = execSync(`openclaw ${args}`, {
+    const result = execSync(`openclaw${profileFlag} ${args}`, {
       encoding: "utf8",
       timeout: 10000,
       env: { ...process.env, NO_COLOR: "1" },
     });
     return result;
   } catch (e) {
-    console.error(`openclaw ${args} failed:`, e.message);
+    console.error(`openclaw${profileFlag} ${args} failed:`, e.message);
     return null;
   }
 }
@@ -1102,7 +1104,9 @@ function getCapacity() {
   // Query active sessions via openclaw CLI
   try {
     // Use openclaw sessions list which actually works (gateway /api/sessions doesn't exist)
-    const response = execSync("openclaw sessions list --json 2>/dev/null", {
+    const profile = process.env.OPENCLAW_PROFILE || "";
+    const profileFlag = profile ? ` --profile ${profile}` : "";
+    const response = execSync(`openclaw${profileFlag} sessions list --json 2>/dev/null`, {
       timeout: 5000,
       encoding: "utf8",
     });


### PR DESCRIPTION
## Summary
- All `openclaw` CLI invocations (via `runOpenClaw()` and one direct `execSync` call) now respect the `OPENCLAW_PROFILE` environment variable
- When set, appends `--profile <name>` to every `openclaw` command
- Backward compatible — no change in behavior when `OPENCLAW_PROFILE` is unset

## Problem
Without `--profile`, `openclaw` uses the default profile which may return non-JSON output (e.g. interactive/styled text with box-drawing characters), causing JSON parse failures and empty session lists on the dashboard.

## Test plan
- [ ] Start dashboard with `OPENCLAW_PROFILE=myprofile npm start` and verify sessions load
- [ ] Start dashboard without `OPENCLAW_PROFILE` and verify no regression (uses default profile)
- [ ] Verify `/api/sessions` returns valid JSON with session data

🤖 Generated with [Claude Code](https://claude.com/claude-code)