### PR TITLE
fix: show auth error instead of 0% for Claude usage

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -2111,6 +2111,137 @@ function serveStatic(req, res) {
 // Get LLM usage stats from state file
 // Transforms raw state data into format expected by renderLlmUsage() frontend
 function getLlmUsage() {
+  // First, try to get fresh data from OpenClaw CLI
+  let liveData = null;
+  let liveError = null;
+  
+  try {
+    const output = execSync("openclaw status --usage --json", {
+      encoding: "utf8",
+      timeout: 10000,
+    });
+    const parsed = JSON.parse(output);
+    if (parsed.usage) {
+      liveData = parsed.usage;
+      // Check for provider-level errors
+      const anthropicProvider = liveData.providers?.find(p => p.provider === "anthropic");
+      if (anthropicProvider?.error) {
+        liveError = anthropicProvider.error;
+      }
+    }
+  } catch (e) {
+    console.error("[getLlmUsage] Failed to fetch live data:", e.message);
+  }
+
+  // If we got live data with actual usage windows, use that
+  if (liveData && !liveError) {
+    const anthropic = liveData.providers?.find(p => p.provider === "anthropic");
+    const codexProvider = liveData.providers?.find(p => p.provider === "openai-codex");
+    
+    const session5h = anthropic?.windows?.find(w => w.label === "5h");
+    const weekAll = anthropic?.windows?.find(w => w.label === "Week");
+    const sonnetWeek = anthropic?.windows?.find(w => w.label === "Sonnet");
+    
+    const codex5h = codexProvider?.windows?.find(w => w.label === "5h");
+    const codexDay = codexProvider?.windows?.find(w => w.label === "Day");
+    
+    // Helper to format reset time
+    const formatReset = (resetAt) => {
+      if (!resetAt) return "?";
+      const now = Date.now();
+      const diff = resetAt - now;
+      if (diff < 0) return "now";
+      if (diff < 3600000) return Math.round(diff / 60000) + "m";
+      if (diff < 86400000) return Math.round(diff / 3600000) + "h";
+      return Math.round(diff / 86400000) + "d";
+    };
+
+    return {
+      timestamp: new Date().toISOString(),
+      source: "live",
+      claude: {
+        session: {
+          usedPct: Math.round(session5h?.usedPercent || 0),
+          remainingPct: Math.round(100 - (session5h?.usedPercent || 0)),
+          resetsIn: formatReset(session5h?.resetAt),
+        },
+        weekly: {
+          usedPct: Math.round(weekAll?.usedPercent || 0),
+          remainingPct: Math.round(100 - (weekAll?.usedPercent || 0)),
+          resets: formatReset(weekAll?.resetAt),
+        },
+        sonnet: {
+          usedPct: Math.round(sonnetWeek?.usedPercent || 0),
+          remainingPct: Math.round(100 - (sonnetWeek?.usedPercent || 0)),
+          resets: formatReset(sonnetWeek?.resetAt),
+        },
+        lastSynced: new Date().toISOString(),
+      },
+      codex: {
+        sessionsToday: 0,
+        tasksToday: 0,
+        usage5hPct: Math.round(codex5h?.usedPercent || 0),
+        usageDayPct: Math.round(codexDay?.usedPercent || 0),
+      },
+      routing: {
+        total: 0,
+        claudeTasks: 0,
+        codexTasks: 0,
+        claudePct: 0,
+        codexPct: 0,
+        codexFloor: 20,
+      },
+    };
+  }
+
+  // If live data had an error, return that error prominently
+  if (liveError) {
+    // Still try to get routing stats from local file
+    const stateFile = path.join(PATHS.state, "llm-routing.json");
+    let routing = { total: 0, claudeTasks: 0, codexTasks: 0, claudePct: 0, codexPct: 0, codexFloor: 20 };
+    let codex = { sessionsToday: 0, tasksToday: 0, usage5hPct: 0, usageDayPct: 0 };
+    
+    try {
+      if (fs.existsSync(stateFile)) {
+        const data = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+        routing = {
+          total: data.routing?.total_tasks || 0,
+          claudeTasks: data.routing?.claude_tasks || 0,
+          codexTasks: data.routing?.codex_tasks || 0,
+          claudePct: data.routing?.total_tasks > 0 
+            ? Math.round((data.routing.claude_tasks / data.routing.total_tasks) * 100) : 0,
+          codexPct: data.routing?.total_tasks > 0
+            ? Math.round((data.routing.codex_tasks / data.routing.total_tasks) * 100) : 0,
+          codexFloor: Math.round((data.routing?.codex_floor_pct || 0.2) * 100),
+        };
+        codex = {
+          sessionsToday: data.codex?.sessions_today || 0,
+          tasksToday: data.codex?.tasks_today || 0,
+          usage5hPct: data.codex?.usage_5h_pct || 0,
+          usageDayPct: data.codex?.usage_day_pct || 0,
+        };
+      }
+    } catch (e) {
+      console.error("[getLlmUsage] Failed to read local state:", e.message);
+    }
+
+    return {
+      timestamp: new Date().toISOString(),
+      source: "error",
+      error: liveError,
+      errorType: liveError.includes("403") ? "auth" : "unknown",
+      claude: {
+        session: { usedPct: null, remainingPct: null, resetsIn: null, error: liveError },
+        weekly: { usedPct: null, remainingPct: null, resets: null, error: liveError },
+        sonnet: { usedPct: null, remainingPct: null, resets: null, error: liveError },
+        lastSynced: null,
+      },
+      codex,
+      routing,
+    };
+  }
+
+  // Fallback: read from state file
   const stateFile = path.join(PATHS.state, "llm-routing.json");
   try {
     if (!fs.existsSync(stateFile)) {
@@ -2121,6 +2252,7 @@ function getLlmUsage() {
     // Transform for dashboard display - match renderLlmUsage() expectations
     return {
       timestamp: new Date().toISOString(),
+      source: "file",
       claude: {
         session: {
           usedPct: Math.round((data.claude?.session?.used_pct || 0) * 100),

--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -1288,6 +1288,9 @@
       .vital-bar-fill.purple {
         background: linear-gradient(90deg, #8957e5, #a371f7);
       }
+      .vital-bar-fill.gray {
+        background: linear-gradient(90deg, #484f58, #6e7681);
+      }
 
       .vital-detail {
         display: flex;

--- a/public/index.html
+++ b/public/index.html
@@ -2190,6 +2190,69 @@
       }
 
       function renderLlmUsage(data) {
+        // Handle auth errors - show clear error state instead of 0%
+        if (data?.errorType === "auth" || data?.claude?.session?.error) {
+          const errorMsg = "⚠️ Auth Error";
+          const errorDetail = "API key lacks user:profile scope";
+          
+          // Session card
+          document.getElementById("claude-session-pct").innerHTML = 
+            '<span style="color:#f59e0b">N/A</span>';
+          document.getElementById("claude-session-bar").style.width = "0%";
+          document.getElementById("claude-session-bar").className = "vital-bar-fill gray";
+          document.getElementById("claude-session-remaining").textContent = "N/A";
+          document.getElementById("claude-session-reset").textContent = "Auth Error";
+          
+          // Weekly card
+          document.getElementById("claude-weekly-pct").innerHTML = 
+            '<span style="color:#f59e0b">N/A</span>';
+          document.getElementById("claude-weekly-bar").style.width = "0%";
+          document.getElementById("claude-weekly-bar").className = "vital-bar-fill gray";
+          document.getElementById("claude-weekly-remaining").textContent = "N/A";
+          document.getElementById("claude-weekly-reset").textContent = "Auth Error";
+          
+          // Sonnet card
+          document.getElementById("sonnet-weekly-pct").innerHTML = 
+            '<span style="color:#f59e0b">N/A</span>';
+          document.getElementById("sonnet-weekly-bar").style.width = "0%";
+          document.getElementById("sonnet-weekly-bar").className = "vital-bar-fill gray";
+          document.getElementById("sonnet-weekly-remaining").textContent = "N/A";
+          document.getElementById("sonnet-weekly-reset").textContent = "Auth Error";
+          
+          // Compact cards
+          const compactSessionEl = document.getElementById("claude-compact-session-pct");
+          const compactSessionBar = document.getElementById("claude-compact-session-bar");
+          if (compactSessionEl) compactSessionEl.textContent = "N/A";
+          if (compactSessionBar) {
+            compactSessionBar.style.width = "0%";
+            compactSessionBar.className = "quota-bar-fill gray";
+          }
+          const compactWeekEl = document.getElementById("claude-compact-week-pct");
+          const compactWeekBar = document.getElementById("claude-compact-week-bar");
+          if (compactWeekEl) compactWeekEl.textContent = "N/A";
+          if (compactWeekBar) {
+            compactWeekBar.style.width = "0%";
+            compactWeekBar.className = "quota-bar-fill gray";
+          }
+          
+          document.getElementById("llm-sync-time").textContent = errorMsg;
+          
+          // Still render routing data if available
+          if (data.routing) {
+            const ct = data.routing.claudeTasks || 0;
+            const cx = data.routing.codexTasks || 0;
+            const total = data.routing.total || 0;
+            document.getElementById("llm-routing-summary").textContent =
+              total > 0 ? `${ct} Claude / ${cx} Codex (${total} tasks)` : "No coding tasks yet";
+            
+            // Task routing counts
+            document.getElementById("codex-tasks").textContent = total + " total";
+            document.getElementById("claude-task-count").textContent = ct;
+            document.getElementById("codex-task-count").textContent = cx;
+          }
+          return;
+        }
+        
         if (!data || data.error) {
           document.getElementById("llm-sync-time").textContent = data?.needsSync
             ? "Needs sync"
@@ -2203,6 +2266,8 @@
           const ago = Math.round((Date.now() - synced) / 60000);
           document.getElementById("llm-sync-time").textContent =
             ago < 60 ? `${ago}m ago` : `${Math.round(ago / 60)}h ago`;
+        } else if (data.source === "live") {
+          document.getElementById("llm-sync-time").textContent = "Live";
         }
 
         // Routing summary - show task counts clearly


### PR DESCRIPTION
## Problem
The Claude usage display showed "0% used" for both Session and Weekly usage, which is incorrect and misleading.

## Root Cause
The Anthropic API key doesn't have the `user:profile` OAuth scope needed to query usage data. The `openclaw status --usage --json` command returns:
```
HTTP 403: OAuth token does not meet scope requirement user:profile
```

## Solution
1. **Server**: Modified `getLlmUsage()` to:
   - Fetch live data from `openclaw status --usage --json`
   - Detect auth errors (HTTP 403) in the response
   - Return proper error structure with `errorType: "auth"`
   - Fall back to local state file for routing/task data

2. **Frontend**: Updated `renderLlmUsage()` to:
   - Detect auth error state
   - Display "N/A" instead of "0%" 
   - Show "Auth Error" for reset times
   - Use gray bars to indicate unavailable data
   - Still show routing stats from local state

## Result
Instead of misleading "0% used", users now see:
- "N/A" for usage percentages
- "Auth Error" for reset times  
- Gray bars indicating data is unavailable
- Clear indication that this is an auth issue, not actual 0% usage

## Testing
- Verified API returns correct error structure
- Added gray color class for CSS bars

Fixes issue raised in #cc-dashboard thread.