### PR TITLE
fix: session counters now correctly identify main vs sub-agent sessions

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -917,6 +917,10 @@ function getSessions(options = {}) {
         let channel = "other";
         if (s.key.includes("slack")) channel = "slack";
         else if (s.key.includes("telegram")) channel = "telegram";
+        else if (s.key.includes("discord")) channel = "discord";
+        else if (s.key.includes(":subagent:")) channel = "subagent";
+        else if (s.key.includes(":cron:")) channel = "cron";
+        else if (s.key === "agent:main:main") channel = "main";
 
         const originator = getSessionOriginator(s.sessionId);
 
@@ -1187,6 +1191,38 @@ function getCapacity() {
     // Fall back to defaults
   }
 
+  // Try to get active counts from sessions list (preferred - has full session keys)
+  try {
+    const output = runOpenClaw("sessions list --json 2>/dev/null");
+    const jsonStr = extractJSON(output);
+    if (jsonStr) {
+      const data = JSON.parse(jsonStr);
+      const sessions = data.sessions || [];
+      const fiveMinMs = 5 * 60 * 1000;
+      
+      for (const s of sessions) {
+        // Only count sessions active in last 5 minutes
+        if (s.ageMs > fiveMinMs) continue;
+        
+        const key = s.key || "";
+        // Session key patterns:
+        //   agent:main:slack:... = main (human-initiated)
+        //   agent:main:telegram:... = main
+        //   agent:main:discord:... = main
+        //   agent:main:subagent:... = subagent (spawned task)
+        //   agent:main:cron:... = cron job (count as subagent)
+        if (key.includes(":subagent:") || key.includes(":cron:")) {
+          result.subagent.active++;
+        } else {
+          result.main.active++;
+        }
+      }
+      return result;
+    }
+  } catch (e) {
+    console.error("Failed to get capacity from sessions list, falling back to filesystem:", e.message);
+  }
+
   // Count active sessions from filesystem (workaround for CLI returning styled text)
   // Sessions active in last 5 minutes are considered "active"
   try {
@@ -1206,9 +1242,31 @@ function getCapacity() {
           // Only count files modified in last 5 minutes as "active"
           if (stat.mtimeMs < fiveMinAgo) continue;
 
-          // Subagent sessions have "subagent" in the filename or key
-          // Main sessions are everything else
-          if (file.includes("subagent")) {
+          // Read the first line to get the session key
+          // Session keys indicate session type:
+          //   agent:main:slack:... = main (human-initiated slack)
+          //   agent:main:telegram:... = main (human-initiated telegram)
+          //   agent:main:discord:... = main (human-initiated discord)
+          //   agent:main:subagent:... = subagent (spawned autonomous task)
+          //   agent:main:cron:... = cron job (automated, count as subagent)
+          // Filenames are just UUIDs, so we must read the content
+          let isSubagent = false;
+          try {
+            const fd = fs.openSync(filePath, "r");
+            const buffer = Buffer.alloc(512); // First 512 bytes is enough for the first line
+            fs.readSync(fd, buffer, 0, 512, 0);
+            fs.closeSync(fd);
+            const firstLine = buffer.toString("utf8").split("\n")[0];
+            const parsed = JSON.parse(firstLine);
+            const key = parsed.key || parsed.id || "";
+            // Subagent and cron sessions are not human-initiated
+            isSubagent = key.includes(":subagent:") || key.includes(":cron:");
+          } catch (parseErr) {
+            // If we can't parse, fall back to checking filename (legacy)
+            isSubagent = file.includes("subagent");
+          }
+
+          if (isSubagent) {
             subActive++;
           } else {
             mainActive++;
@@ -1375,12 +1433,13 @@ function getFullState() {
   let cerebro = {};
   let subagents = [];
   
-  // Sessions now work reliably with extractJSON() to handle doctor warnings
+  // Get ALL sessions first for accurate statusCounts, then slice for display
+  let allSessions = [];
   let totalSessionCount = 0;
   try {
-    const result = getSessions({ limit: 20, returnCount: true });
-    sessions = result.sessions;
-    totalSessionCount = result.totalCount;
+    allSessions = getSessions({ limit: null }); // Get all for counting
+    totalSessionCount = allSessions.length;
+    sessions = allSessions.slice(0, 20); // Display only first 20
   } catch (e) { console.error("[State] sessions:", e.message); }
   
   try { vitals = getSystemVitals(); } catch (e) { console.error("[State] vitals:", e.message); }
@@ -1388,17 +1447,16 @@ function getFullState() {
   try { capacity = getCapacity(); } catch (e) { console.error("[State] capacity:", e.message); }
   // Pass capacity to tokenStats so it can use the same active counts
   try { tokenStats = getTokenStats(sessions, capacity); } catch (e) { console.error("[State] tokenStats:", e.message); }
-  // Note: statusCounts for live/recent/idle are approximations based on current page
-  // Accurate counts require loading all sessions (expensive)
+  // Calculate statusCounts from ALL sessions (not just current page) for accurate filter counts
   try {
-    const liveSessions = sessions.filter((s) => s.active);
-    const recentSessions = sessions.filter((s) => !s.active && s.recentlyActive);
-    const idleSessions = sessions.filter((s) => !s.active && !s.recentlyActive);
+    const liveSessions = allSessions.filter((s) => s.active);
+    const recentSessions = allSessions.filter((s) => !s.active && s.recentlyActive);
+    const idleSessions = allSessions.filter((s) => !s.active && !s.recentlyActive);
     statusCounts = {
       all: totalSessionCount,
       live: liveSessions.length,
       recent: recentSessions.length,
-      idle: totalSessionCount - liveSessions.length - recentSessions.length,
+      idle: idleSessions.length,
     };
   } catch (e) { console.error("[State] statusCounts:", e.message); }
   try { operators = loadOperators(); } catch (e) { console.error("[State] operators:", e.message); }


### PR DESCRIPTION
## Summary
Fixes JON-198: Main/Sub session counters showing 0 active

## Problem
The `getCapacity()` function was checking for 'subagent' in the session *filename*, but session files are named by UUID. The session type info is in the session *key* which is available from `openclaw sessions list --json`.

## Solution
- Use sessions list CLI output to count active sessions by type
- Session keys with `:subagent:` or `:cron:` count as sub-agents
- All other sessions (slack, telegram, discord) count as main
- Fall back to filesystem scanning only if CLI fails

## Testing
```
Main: 1/12 (current Slack thread)
Sub-agents: 5/24 (2 cron + 3 spawned sub-agents)
```

## Linear Issue
https://linear.app/jontsai/issue/JON-198