### PR TITLE
fix(JON-200): Fix session kind filtering and add Cron filter

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -913,14 +913,12 @@ function getSessions(options = {}) {
         // Calculate active status from ageMs
         const minutesAgo = s.ageMs ? s.ageMs / 60000 : Infinity;
 
-        // Determine channel type from key
+        // Determine channel type from key (platform/source only)
+        // Note: subagent/cron are session types, not channels
         let channel = "other";
         if (s.key.includes("slack")) channel = "slack";
         else if (s.key.includes("telegram")) channel = "telegram";
         else if (s.key.includes("discord")) channel = "discord";
-        else if (s.key.includes(":subagent:")) channel = "subagent";
-        else if (s.key.includes(":cron:")) channel = "cron";
-        else if (s.key === "agent:main:main") channel = "main";
 
         const originator = getSessionOriginator(s.sessionId);
 
@@ -930,13 +928,22 @@ function getSessions(options = {}) {
         // Get topic for session (lightweight detection)
         const topic = getSessionTopic(s.sessionId);
 
+        // Derive session type from key (for kind filtering)
+        // - subagent sessions: agent:main:subagent:...
+        // - cron sessions: agent:main:cron:...
+        // - everything else: main
+        let sessionType = "main";
+        if (s.key.includes(":subagent:")) sessionType = "subagent";
+        else if (s.key.includes(":cron:")) sessionType = "cron";
+
         return {
           sessionKey: s.key,
           sessionId: s.sessionId,
           label: label,
           groupChannel: s.groupChannel || null,
           displayName: s.displayName || null,
-          kind: s.kind,
+          kind: sessionType, // Use derived type for filtering (main/subagent/cron)
+          conversationType: s.kind, // Original CLI kind (group/direct) for display
           channel: channel,
           active: minutesAgo < 15,
           recentlyActive: minutesAgo < 60,

--- a/public/index.html
+++ b/public/index.html
@@ -642,6 +642,14 @@
               >
                 📱 Telegram
               </button>
+              <button
+                class="filter-btn"
+                data-filter="discord"
+                data-group="session-channel"
+                onclick="setSessionFilter('channel', 'discord')"
+              >
+                🎮 Discord
+              </button>
             </div>
             <div class="filter-group">
               <span class="filter-label">Kind:</span>
@@ -668,6 +676,14 @@
                 onclick="setSessionFilter('kind', 'subagent')"
               >
                 Subagent
+              </button>
+              <button
+                class="filter-btn"
+                data-filter="cron"
+                data-group="session-kind"
+                onclick="setSessionFilter('kind', 'cron')"
+              >
+                ⏰ Cron
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
Fixes JON-200: Dashboard sessions filter counts incorrect + missing channels

## Issues Fixed

1. **Kind field mapping**: Kind field now uses derived session type (main/subagent/cron) instead of CLI's conversation type (group/direct). The UI filter buttons were looking for 'main'/'subagent' but receiving 'group'/'direct' from the CLI.

2. **Channel detection cleanup**: Channel detection no longer includes subagent/cron/main as channels. These are session types, not communication platforms. Channels are now strictly: slack, telegram, discord, other.

3. **Added Cron filter**: Added 'Cron' filter button to Kind filters - cron job sessions were not filterable before.

4. **Added Discord channel filter**: Added Discord channel filter button for future Discord integration.

5. **Preserved conversationType**: Original CLI kind preserved as 'conversationType' field for potential display use.

## Note
The statusCounts fix (getting ALL sessions for accurate counts) was already applied in a previous commit on this branch.

## Testing
- Filter buttons now correctly show/hide sessions by kind (main/subagent/cron)
- Session status counts (All/Live/Recent/Idle) are accurate
- Discord channel filter ready for future use

## Linear Issue
https://linear.app/jontsai/issue/JON-200