### PR TITLE
perf: async vitals refresh with Promise.all parallelism

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -8,6 +8,23 @@ const http = require("http");
 const fs = require("fs");
 const path = require("path");
 const { execSync, exec } = require("child_process");
+const { promisify } = require("util");
+
+// Promisified exec for async operations
+const execAsync = promisify(exec);
+
+// Helper to run command and return stdout (with timeout and error handling)
+async function runCmd(cmd, options = {}) {
+  const opts = { encoding: "utf8", timeout: 10000, ...options };
+  try {
+    const { stdout } = await execAsync(cmd, opts);
+    return stdout.trim();
+  } catch (e) {
+    if (options.fallback !== undefined) return options.fallback;
+    throw e;
+  }
+}
+
 // Note: jobs module loaded after env vars are set (see below)
 
 // ============================================================================
@@ -398,14 +415,123 @@ function getUnauthorizedPage(reason, user) {
 let cachedVitals = null;
 let lastVitalsUpdate = 0;
 const VITALS_CACHE_TTL = 30000; // 30 seconds - vitals don't change fast
+let vitalsRefreshing = false;
 
-// Get detailed system vitals (iStatMenus-style)
+// Async background refresh of system vitals (non-blocking)
+async function refreshVitalsAsync() {
+  if (vitalsRefreshing) return;
+  vitalsRefreshing = true;
+  
+  const vitals = {
+    hostname: "", uptime: "",
+    disk: { used: 0, free: 0, total: 0, percent: 0, kbPerTransfer: 0, iops: 0, throughputMBps: 0 },
+    cpu: { loadAvg: [0, 0, 0], cores: 0, usage: 0 },
+    memory: { used: 0, free: 0, total: 0, percent: 0, pressure: "normal" },
+    temperature: null,
+  };
+
+  try {
+    // Run commands in parallel for speed
+    const [hostname, uptimeRaw, coresRaw, memTotalRaw, vmStatRaw, dfRaw, topOutput] = await Promise.all([
+      runCmd("hostname", { fallback: "unknown" }),
+      runCmd("uptime", { fallback: "" }),
+      runCmd("sysctl -n hw.ncpu", { fallback: "1" }),
+      runCmd("sysctl -n hw.memsize", { fallback: "0" }),
+      runCmd("vm_stat", { fallback: "" }),
+      runCmd("df -k ~ | tail -1", { fallback: "" }),
+      runCmd('top -l 1 -n 0 2>/dev/null | grep "CPU usage" || echo ""', { fallback: "" }),
+    ]);
+
+    vitals.hostname = hostname;
+
+    // Parse uptime
+    const uptimeMatch = uptimeRaw.match(/up\s+([^,]+)/);
+    if (uptimeMatch) vitals.uptime = uptimeMatch[1].trim();
+    const loadMatch = uptimeRaw.match(/load averages?:\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)/);
+    if (loadMatch) vitals.cpu.loadAvg = [parseFloat(loadMatch[1]), parseFloat(loadMatch[2]), parseFloat(loadMatch[3])];
+
+    // CPU
+    vitals.cpu.cores = parseInt(coresRaw, 10) || 1;
+    vitals.cpu.usage = Math.min(100, Math.round((vitals.cpu.loadAvg[0] / vitals.cpu.cores) * 100));
+    if (topOutput) {
+      const userMatch = topOutput.match(/([\d.]+)%\s*user/);
+      const sysMatch = topOutput.match(/([\d.]+)%\s*sys/);
+      vitals.cpu.userPercent = userMatch ? parseFloat(userMatch[1]) : null;
+      vitals.cpu.sysPercent = sysMatch ? parseFloat(sysMatch[1]) : null;
+      if (vitals.cpu.userPercent !== null && vitals.cpu.sysPercent !== null) {
+        vitals.cpu.usage = Math.round(vitals.cpu.userPercent + vitals.cpu.sysPercent);
+      }
+    }
+
+    // Disk
+    const dfParts = dfRaw.split(/\s+/);
+    if (dfParts.length >= 4) {
+      vitals.disk.total = parseInt(dfParts[1], 10) * 1024;
+      vitals.disk.used = parseInt(dfParts[2], 10) * 1024;
+      vitals.disk.free = parseInt(dfParts[3], 10) * 1024;
+      vitals.disk.percent = Math.round((parseInt(dfParts[2], 10) / parseInt(dfParts[1], 10)) * 100);
+    }
+
+    // Memory
+    vitals.memory.total = parseInt(memTotalRaw, 10) || 0;
+    const pageSize = 16384;
+    const activePages = parseInt((vmStatRaw.match(/Pages active:\s+(\d+)/) || [])[1] || 0, 10);
+    const wiredPages = parseInt((vmStatRaw.match(/Pages wired down:\s+(\d+)/) || [])[1] || 0, 10);
+    const compressedPages = parseInt((vmStatRaw.match(/Pages occupied by compressor:\s+(\d+)/) || [])[1] || 0, 10);
+    vitals.memory.used = (activePages + wiredPages + compressedPages) * pageSize;
+    vitals.memory.free = vitals.memory.total - vitals.memory.used;
+    vitals.memory.percent = vitals.memory.total > 0 ? Math.round((vitals.memory.used / vitals.memory.total) * 100) : 0;
+    vitals.memory.pressure = vitals.memory.percent > 90 ? "critical" : vitals.memory.percent > 75 ? "warning" : "normal";
+
+    // Secondary async calls (chip info, iostat)
+    const [perfCores, effCores, chip, iostatRaw] = await Promise.all([
+      runCmd("sysctl -n hw.perflevel0.logicalcpu 2>/dev/null || echo 0", { fallback: "0" }),
+      runCmd("sysctl -n hw.perflevel1.logicalcpu 2>/dev/null || echo 0", { fallback: "0" }),
+      runCmd('system_profiler SPHardwareDataType 2>/dev/null | grep "Chip:" | cut -d: -f2 || echo ""', { fallback: "" }),
+      runCmd("iostat -d -c 2 2>/dev/null | tail -1 || echo ''", { fallback: "" }),
+    ]);
+    vitals.cpu.pCores = parseInt(perfCores, 10) || null;
+    vitals.cpu.eCores = parseInt(effCores, 10) || null;
+    if (chip) vitals.cpu.chip = chip;
+    const iostatParts = iostatRaw.split(/\s+/);
+    if (iostatParts.length >= 3) {
+      vitals.disk.kbPerTransfer = parseFloat(iostatParts[0]) || 0;
+      vitals.disk.iops = parseFloat(iostatParts[1]) || 0;
+      vitals.disk.throughputMBps = parseFloat(iostatParts[2]) || 0;
+    }
+    vitals.temperatureNote = vitals.cpu.chip ? "Apple Silicon (requires elevated access)" : null;
+  } catch (e) {
+    console.error("[Vitals] Async refresh failed:", e.message);
+  }
+
+  // Formatted versions
+  vitals.memory.usedFormatted = formatBytes(vitals.memory.used);
+  vitals.memory.totalFormatted = formatBytes(vitals.memory.total);
+  vitals.memory.freeFormatted = formatBytes(vitals.memory.free);
+  vitals.disk.usedFormatted = formatBytes(vitals.disk.used);
+  vitals.disk.totalFormatted = formatBytes(vitals.disk.total);
+  vitals.disk.freeFormatted = formatBytes(vitals.disk.free);
+
+  cachedVitals = vitals;
+  lastVitalsUpdate = Date.now();
+  vitalsRefreshing = false;
+  console.log("[Vitals] Cache refreshed async");
+}
+
+// Start background vitals refresh on startup
+setTimeout(() => refreshVitalsAsync(), 500);
+setInterval(() => refreshVitalsAsync(), VITALS_CACHE_TTL);
+
+// Get detailed system vitals (iStatMenus-style) - returns cached, triggers async refresh
 function getSystemVitals() {
   const now = Date.now();
-  if (cachedVitals && (now - lastVitalsUpdate) < VITALS_CACHE_TTL) {
-    return cachedVitals;
+  // Always return cached if available, trigger async refresh if stale
+  if (!cachedVitals || (now - lastVitalsUpdate) > VITALS_CACHE_TTL) {
+    refreshVitalsAsync(); // Non-blocking
   }
+  if (cachedVitals) return cachedVitals;
   
+  // Fallback for first load only (will be replaced by async result quickly)
   const vitals = {
     hostname: "",
     uptime: "",


### PR DESCRIPTION
## Changes
- Add `runCmd()` helper for promisified exec with fallback
- Add `refreshVitalsAsync()` that runs system commands in parallel  
- Modify `getSystemVitals()` to return cached data immediately
- Background refresh on startup and every 30 seconds
- Old sync code remains as fallback for first load only

## Performance
- Vitals calls no longer block the event loop
- Commands run in parallel via `Promise.all`
- ~10-15 parallel commands complete faster than sequential

## Related
- Part of JON-197 async refactor
- Builds on LLM usage async work (ebbea00)

## Testing
- Syntax verified with `node --check`
- Manual testing needed on live dashboard