### PR TITLE
fix: correct savings math - compare monthly to monthly

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -2005,10 +2005,11 @@ function getTokenStats(sessions, capacity) {
   const cacheWriteCost = ((daily?.cacheWrite || 0) / 1_000_000) * rates.cacheWrite;
   const estCost = inputCost + outputCost + cacheReadCost + cacheWriteCost;
 
-  // Calculate savings vs plan cost
+  // Calculate savings vs plan cost (compare monthly to monthly)
   const planCost = CONFIG.billing?.claudePlanCost || 200;
   const planName = CONFIG.billing?.claudePlanName || "Claude Code Max";
-  const savings = estCost - planCost;
+  const monthlyEstCost = estCost * 30;  // Project daily to monthly
+  const savings = monthlyEstCost - planCost;
   const savingsPositive = savings > 0;
 
   return {
@@ -2027,7 +2028,8 @@ function getTokenStats(sessions, capacity) {
     planCost: `$${planCost.toFixed(0)}`,
     planName,
     estSavings: savingsPositive ? `$${formatNumber(savings)}` : null,
-    savingsPercent: savingsPositive ? Math.round((savings / estCost) * 100) : 0,
+    savingsPercent: savingsPositive ? Math.round((savings / monthlyEstCost) * 100) : 0,
+    monthlyEstCost: `$${formatNumber(monthlyEstCost)}`,
   };
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -2825,25 +2825,28 @@ Jonathan Tsai (@jontsai)
           </div>
         `;
         
-        // Savings
-        const savings = (data.totalCost || 0) - (data.planCost || 200);
-        const savingsPercent = data.totalCost > 0 ? Math.round((savings / data.totalCost) * 100) : 0;
-        const monthlyProjection = Math.round(data.totalCost * 30);
+        // Savings - compare monthly to monthly (not daily to monthly)
+        const monthlyProjection = Math.round((data.totalCost || 0) * 30);
+        const planCost = data.planCost || 200;
+        const savings = monthlyProjection - planCost;
+        const savingsPercent = monthlyProjection > 0 ? Math.round((savings / monthlyProjection) * 100) : 0;
         document.getElementById("cost-savings").innerHTML = savings > 0 ? `
-          <div class="detail-row"><span class="detail-label">${data.planName || 'Claude Plan'}</span><span class="detail-value">$${data.planCost || 200}/month</span></div>
+          <div class="detail-row"><span class="detail-label">${data.planName || 'Claude Plan'}</span><span class="detail-value">$${planCost}/month</span></div>
           <div class="detail-row"><span class="detail-label">Est. API Cost (24h)</span><span class="detail-value">$${formatCurrency(data.totalCost)}</span></div>
+          <div class="detail-row"><span class="detail-label">Est. Monthly Cost</span><span class="detail-value">$${monthlyProjection.toLocaleString()}/month</span></div>
           <div class="detail-row" style="border-top: 1px solid var(--border); padding-top: 8px; margin-top: 8px;">
-            <span class="detail-label"><strong>Est. Savings</strong></span>
-            <span class="detail-value" style="color: var(--green);"><strong>$${formatCurrency(savings)} (${savingsPercent}%)</strong></span>
+            <span class="detail-label"><strong>Est. Monthly Savings</strong></span>
+            <span class="detail-value" style="color: var(--green);"><strong>$${savings.toLocaleString()} (${savingsPercent}%)</strong></span>
           </div>
           <p style="margin-top: 12px; font-size: 0.85rem; color: var(--text-muted);">
-            💡 At this rate, your monthly API cost would be ~$${monthlyProjection.toLocaleString()}/mo vs your $${data.planCost}/mo plan.
+            💡 At this rate, you're saving ~$${savings.toLocaleString()}/mo with your flat-rate plan!
           </p>
         ` : `
-          <div class="detail-row"><span class="detail-label">${data.planName || 'Claude Plan'}</span><span class="detail-value">$${data.planCost || 200}/month</span></div>
+          <div class="detail-row"><span class="detail-label">${data.planName || 'Claude Plan'}</span><span class="detail-value">$${planCost}/month</span></div>
           <div class="detail-row"><span class="detail-label">Est. API Cost (24h)</span><span class="detail-value">$${formatCurrency(data.totalCost)}</span></div>
+          <div class="detail-row"><span class="detail-label">Est. Monthly Cost</span><span class="detail-value">$${monthlyProjection.toLocaleString()}/month</span></div>
           <p style="margin-top: 12px; font-size: 0.85rem; color: var(--text-muted);">
-            📈 Keep going! Once your 24h est. cost exceeds $${data.planCost || 200}, you'll start seeing savings.
+            📈 Keep going! Once your monthly est. cost exceeds $${planCost}, you'll start seeing savings.
           </p>
         `;
       }


### PR DESCRIPTION
## Problem
Was subtracting monthly plan cost ($200) from daily API cost ($2,832.78), showing 93% savings.

Should compare monthly projections:
- Monthly API cost: $84,983/mo
- Plan cost: $200/mo  
- Savings: $84,783/mo (99.76%)

## Changes
- Frontend: Calculate savings from monthlyProjection, not daily cost
- Backend: Project estCost to monthly before calculating savings
- UI: Added 'Est. Monthly Cost' row for clarity
- UI: Changed 'Est. Savings' to 'Est. Monthly Savings'

## Before
```
Est. Savings: $2,632.78 (93%)
```

## After
```
Est. Monthly Cost: $84,983/month
Est. Monthly Savings: $84,783 (99%)
```

Fixes feedback from early tester.