### PR TITLE
security: harden static serving, localhost auth bypass, and CORS defaults

### DIFF
--- a/config/dashboard.example.json
+++ b/config/dashboard.example.json
@@ -27,9 +27,15 @@
     "mode": "none",
     "_modeOptions": "none | token | tailscale | cloudflare | allowlist",
     "token": null,
+    "allowLocalhostBypass": false,
     "allowedUsers": [],
     "allowedIPs": ["127.0.0.1", "::1"],
     "publicPaths": ["/api/health", "/api/whoami", "/favicon.ico"]
+  },
+
+  "cors": {
+    "_comment": "Same-origin by default. Add explicit origins only when needed.",
+    "allowedOrigins": []
   },
 
   "dashboard": {

--- a/lib/config.js
+++ b/lib/config.js
@@ -230,6 +230,10 @@ function loadConfig() {
     auth: {
       mode: process.env.DASHBOARD_AUTH_MODE || fileConfig.auth?.mode || "none",
       token: process.env.DASHBOARD_TOKEN || fileConfig.auth?.token,
+      // Off by default: avoid implicit auth bypasses unless explicitly opted in
+      allowLocalhostBypass:
+        process.env.DASHBOARD_ALLOW_LOCALHOST_BYPASS === "true" ||
+        fileConfig.auth?.allowLocalhostBypass === true,
       allowedUsers: (
         process.env.DASHBOARD_ALLOWED_USERS ||
         fileConfig.auth?.allowedUsers?.join(",") ||
@@ -246,6 +250,18 @@ function loadConfig() {
         .split(",")
         .map((s) => s.trim()),
       publicPaths: fileConfig.auth?.publicPaths || ["/api/health", "/api/whoami", "/favicon.ico"],
+    },
+
+    // CORS settings (default: same-origin only; no wildcard)
+    cors: {
+      allowedOrigins: (
+        process.env.DASHBOARD_CORS_ORIGINS ||
+        fileConfig.cors?.allowedOrigins?.join(",") ||
+        ""
+      )
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
     },
 
     // Branding

--- a/lib/server.js
+++ b/lib/server.js
@@ -89,9 +89,14 @@ const DASHBOARD_DIR = path.join(__dirname, "../public");
 const AUTH_CONFIG = {
   mode: CONFIG.auth.mode,
   token: CONFIG.auth.token,
+  allowLocalhostBypass: CONFIG.auth.allowLocalhostBypass === true,
   allowedUsers: CONFIG.auth.allowedUsers,
   allowedIPs: CONFIG.auth.allowedIPs,
   publicPaths: CONFIG.auth.publicPaths,
+};
+
+const CORS_CONFIG = {
+  allowedOrigins: Array.isArray(CONFIG.cors?.allowedOrigins) ? CONFIG.cors.allowedOrigins : [],
 };
 
 // Auth header names
@@ -443,11 +448,11 @@ function formatTimeAgo(date) {
 function checkAuth(req) {
   const mode = AUTH_CONFIG.mode;
 
-  // Always allow localhost access (for direct physical machine access)
+  // Optional localhost bypass (disabled by default)
   const remoteAddr = req.socket?.remoteAddress || "";
   const isLocalhost =
     remoteAddr === "127.0.0.1" || remoteAddr === "::1" || remoteAddr === "::ffff:127.0.0.1";
-  if (isLocalhost) {
+  if (isLocalhost && AUTH_CONFIG.allowLocalhostBypass) {
     return { authorized: true, user: { type: "localhost", login: "localhost" } };
   }
 
@@ -2988,28 +2993,49 @@ created: ${new Date().toISOString().split("T")[0]}
   };
 }
 
-// Serve static files
-function serveStatic(req, res) {
-  let filePath = req.url === "/" ? "/index.html" : req.url;
-  filePath = path.join(DASHBOARD_DIR, filePath);
+// Serve static files safely (prevents path traversal)
+function resolveSafeStaticPath(rawPathname) {
+  try {
+    const requested = rawPathname === "/" ? "/index.html" : rawPathname;
+    const decoded = decodeURIComponent(requested);
+    const normalized = path.posix.normalize(decoded).replace(/^\/+/, "");
+    const absolutePath = path.resolve(DASHBOARD_DIR, normalized);
+    const publicRoot = path.resolve(DASHBOARD_DIR) + path.sep;
+
+    if (absolutePath !== path.resolve(DASHBOARD_DIR) && !absolutePath.startsWith(publicRoot)) {
+      return null;
+    }
+    return absolutePath;
+  } catch {
+    return null;
+  }
+}
+
+function serveStatic(req, res, pathname) {
+  const filePath = resolveSafeStaticPath(pathname || "/");
+  if (!filePath) {
+    res.writeHead(403, { "Content-Type": "text/plain" });
+    res.end("Forbidden");
+    return;
+  }
 
   const ext = path.extname(filePath);
   const contentTypes = {
-    ".html": "text/html",
-    ".css": "text/css",
-    ".js": "text/javascript",
-    ".json": "application/json",
+    ".html": "text/html; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".js": "text/javascript; charset=utf-8",
+    ".json": "application/json; charset=utf-8",
     ".png": "image/png",
     ".svg": "image/svg+xml",
   };
 
   fs.readFile(filePath, (err, content) => {
     if (err) {
-      res.writeHead(404);
+      res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not found");
       return;
     }
-    res.writeHead(200, { "Content-Type": contentTypes[ext] || "text/plain" });
+    res.writeHead(200, { "Content-Type": contentTypes[ext] || "application/octet-stream" });
     res.end(content);
   });
 }
@@ -3475,12 +3501,30 @@ function executeAction(action) {
 
 // Create server
 const server = http.createServer((req, res) => {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
+  // Baseline security headers
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Referrer-Policy", "no-referrer");
+  res.setHeader("X-Frame-Options", "DENY");
 
-  const urlParts = req.url.split("?");
-  const pathname = urlParts[0];
-  const query = new URLSearchParams(urlParts[1] || "");
+  // Parse URL safely
+  const requestUrl = new URL(req.url || "/", "http://localhost");
+  const pathname = requestUrl.pathname;
+  const query = requestUrl.searchParams;
+
+  // CORS: same-origin by default; allow only explicit origins
+  const origin = req.headers.origin;
+  if (origin && CORS_CONFIG.allowedOrigins.includes(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+    res.setHeader("Vary", "Origin");
+    res.setHeader("Access-Control-Allow-Methods", "GET,POST,PUT,OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  }
+
+  if (req.method === "OPTIONS") {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
 
   // Fast path for health check - bypasses all processing
   if (pathname === "/api/health") {
@@ -3869,7 +3913,7 @@ const server = http.createServer((req, res) => {
     // Jobs Framework API - handles /api/jobs/*
     handleJobsRequest(req, res, pathname, query, req.method);
   } else {
-    serveStatic(req, res);
+    serveStatic(req, res, pathname);
   }
 });
 
@@ -3878,6 +3922,9 @@ server.listen(PORT, () => {
   console.log(`🦞 OpenClaw Command Center running at http://localhost:${PORT}`);
   if (profile) {
     console.log(`   Profile: ${profile} (~/.openclaw-${profile})`);
+  }
+  if (AUTH_CONFIG.mode === "none") {
+    console.warn("⚠️  Auth mode is 'none' (local/dev only). Set DASHBOARD_AUTH_MODE=token|tailscale|cloudflare for production.");
   }
   console.log(`   Press Ctrl+C to stop`);
 

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -71,6 +71,14 @@ describe("server", () => {
       `Expected 2xx/3xx/4xx status for root, got: ${statusCode}`,
     );
   });
+
+  it("blocks path traversal attempts", async () => {
+    const { statusCode } = await httpGet(`http://localhost:${TEST_PORT}/../../etc/passwd`);
+    assert.ok(
+      statusCode === 403 || statusCode === 404,
+      `Expected 403/404 for traversal path, got: ${statusCode}`,
+    );
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary
This PR hardens default security posture and closes a path traversal risk in static file serving.

### Changes
- Fix static file path traversal by normalizing/decoding and enforcing `public/` root containment
- Remove implicit localhost auth bypass by default (now explicit opt-in via `auth.allowLocalhostBypass` / `DASHBOARD_ALLOW_LOCALHOST_BYPASS=true`)
- Replace permissive `Access-Control-Allow-Origin: *` behavior with explicit allowlist-based CORS (`cors.allowedOrigins` / `DASHBOARD_CORS_ORIGINS`)
- Add preflight (`OPTIONS`) handling
- Add baseline hardening headers:
  - `X-Content-Type-Options: nosniff`
  - `Referrer-Policy: no-referrer`
  - `X-Frame-Options: DENY`
- Extend `dashboard.example.json` with new auth/cors options
- Add regression test to ensure traversal attempts are blocked

## Why
The server previously joined URL paths directly against the static root and allowed wildcard CORS, which can be unsafe for exposed deployments. This patch tightens defaults while preserving explicit opt-in behavior for local/dev workflows.

## Validation
- `npm test` (all passing)
- Added dedicated traversal test in `tests/server.test.js`

## Backward compatibility
- Existing local workflows continue to work with `auth.mode=none`
- Localhost auth bypass is now explicit rather than implicit
- Cross-origin access now requires explicit allowlist configuration
