### PR TITLE
feat: add Linux support for system vitals and Discord operator detection

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -127,7 +127,11 @@ function broadcastSSE(event, data) {
     sendSSE(client, event, data);
   }
 }
-const DATA_DIR = path.join(DASHBOARD_DIR, "data");
+
+// Use persistent data directory outside skill folder for survival across updates
+const HOME = process.env.HOME || require("os").homedir();
+const PERSISTENT_DATA_DIR = path.join(HOME, ".openclaw-command-center", "data");
+const DATA_DIR = PERSISTENT_DATA_DIR;
 
 // ============================================================================
 // PRIVACY SETTINGS


### PR DESCRIPTION
## Summary

Adds cross-platform Linux support for the Command Center dashboard, enabling proper system vitals reporting on Linux systems.

## Changes

### System Vitals (Cross-Platform)

- **CPU Cores**: Uses `nproc` on Linux, `sysctl -n hw.ncpu` on macOS
- **Memory**: Parses `/proc/meminfo` on Linux, `vm_stat` on macOS
- **CPU Usage**: Parses `top -bn1` output on Linux (different format than macOS)
- **Temperature**: Tries multiple Linux sources:
  - `lm-sensors` (JSON and text output)
  - `/sys/class/hwmon/hwmon*/temp*_input`
  - `/sys/class/thermal/thermal_zone*/temp`
- **CPU Brand**: Reads from `/proc/cpuinfo` on Linux

### Operator Detection

- Added Discord operator auto-detection from session transcripts
- Parses the "Conversation info" JSON block that OpenClaw injects
- Extracts Discord user ID, label (display name), and username

## Testing

Tested on:
- **Linux**: AMD Ryzen 5 5500U with Radeon Graphics (8 cores, 7.7GB RAM)
- **Temperature**: Hardware sensors not exposed on this laptop (common issue), gracefully shows no data

## Screenshots

Before (Linux):
- CPU Cores: 1 (incorrect)
- CPU Brand: (empty)
- Temperature: (error)

After (Linux):
- CPU Cores: 8 (correct)
- CPU Brand: AMD Ryzen 5 5500U with Radeon Graphics
- Temperature: null (no sensors available, no error shown)

## Related

- Preserves all macOS-specific functionality (Apple Silicon detection, Intel Mac temperature via osx-cpu-temp)