### PR TITLE
fix: add test isolation for jobs API availability test

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -13,11 +13,13 @@ const JOBS_DIR = CONFIG.paths.jobs;
 const JOBS_STATE_DIR = path.join(CONFIG.paths.state, "jobs");
 
 let apiInstance = null;
+let forceApiUnavailable = false; // For testing
 
 /**
  * Initialize the jobs API (lazy-loaded due to ESM)
  */
 async function getAPI() {
+  if (forceApiUnavailable) return null;
   if (apiInstance) return apiInstance;
 
   try {
@@ -31,6 +33,16 @@ async function getAPI() {
     console.error("Failed to load jobs API:", e.message);
     return null;
   }
+}
+
+/**
+ * Reset API state for testing purposes
+ * @param {Object} options - Reset options
+ * @param {boolean} options.forceUnavailable - If true, getAPI() will return null
+ */
+function _resetForTesting(options = {}) {
+  apiInstance = null;
+  forceApiUnavailable = options.forceUnavailable || false;
 }
 
 /**
@@ -246,4 +258,4 @@ function isJobsRoute(pathname) {
   return pathname.startsWith("/api/jobs");
 }
 
-module.exports = { handleJobsRequest, isJobsRoute };
+module.exports = { handleJobsRequest, isJobsRoute, _resetForTesting };

--- a/tests/jobs.test.js
+++ b/tests/jobs.test.js
@@ -1,10 +1,10 @@
-const { describe, it } = require("node:test");
+const { describe, it, afterEach } = require("node:test");
 const assert = require("node:assert");
 
 // We import the module to test its exports and pure functions.
 // The jobs module relies on dynamic ESM import of external jobs API,
 // so we focus on testing what's available without that dependency.
-const { handleJobsRequest, isJobsRoute } = require("../lib/jobs");
+const { handleJobsRequest, isJobsRoute, _resetForTesting } = require("../lib/jobs");
 
 describe("jobs module", () => {
   describe("exports", () => {
@@ -60,7 +60,15 @@ describe("jobs module", () => {
   });
 
   describe("handleJobsRequest()", () => {
+    afterEach(() => {
+      // Reset API state after each test
+      _resetForTesting();
+    });
+
     it("returns 500 when jobs API is not available", async () => {
+      // Force API to be unavailable for this test
+      _resetForTesting({ forceUnavailable: true });
+
       let statusCode = null;
       let body = null;
 


### PR DESCRIPTION
## Summary

- Add `_resetForTesting()` function to jobs module for test isolation
- Fix flaky test that expected 500 but got 200 due to singleton state

## Problem

The test "returns 500 when jobs API is not available" was failing because the API singleton was already initialized from previous test runs or module loading. The test expected `getAPI()` to return `null`, but it was returning the cached instance.

## Solution

Added a `_resetForTesting()` function that:
- Resets the cached API singleton to `null`
- Optionally forces `getAPI()` to return `null` via `forceUnavailable` option

The test now properly simulates an unavailable API by calling:
```js
_resetForTesting({ forceUnavailable: true });
```

## Test plan

- [x] All 64 tests pass
- [x] The specific failing test now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)