### PR TITLE
feat: add Discord operator auto-detection from session transcripts

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -353,6 +353,37 @@ async function refreshOperatorsAsync() {
               }
               break;
             }
+
+            // Check for Discord users in "Conversation info" JSON block
+            // Pattern: "sender": "123456789012345678" and "label": "CoolUser123"
+            const discordSenderMatch = text.match(/"sender":\s*"(\d+)"/);
+            const discordLabelMatch = text.match(/"label":\s*"([^"]+)"/);
+            const discordUsernameMatch = text.match(/"username":\s*"([^"]+)"/);
+
+            if (discordSenderMatch) {
+              const userId = discordSenderMatch[1];
+              const label = discordLabelMatch ? discordLabelMatch[1] : userId;
+              const username = discordUsernameMatch ? discordUsernameMatch[1] : label;
+              const opId = `discord:${userId}`;
+
+              if (!operatorsMap.has(opId)) {
+                operatorsMap.set(opId, {
+                  id: opId,
+                  discordId: userId,
+                  name: label,
+                  username: username,
+                  source: "discord",
+                  firstSeen: entry.timestamp || stat.mtimeMs,
+                  lastSeen: entry.timestamp || stat.mtimeMs,
+                  sessionCount: 1,
+                });
+              } else {
+                const op = operatorsMap.get(opId);
+                op.lastSeen = Math.max(op.lastSeen, entry.timestamp || stat.mtimeMs);
+                op.sessionCount++;
+              }
+              break;
+            }
           } catch (e) {
             /* skip invalid lines */
           }


### PR DESCRIPTION
## Summary

- Add automatic detection of Discord users from OpenClaw session transcripts
- Parses "Conversation info" JSON blocks injected by Discord bots

## Changes

Detects Discord operator information from session transcripts:
- `sender`: Discord user ID
- `label`: Display name  
- `username`: Discord username

Creates operator entries with `discord:` prefix (e.g., `discord:123456789012345678`).

## Test plan

- [x] All 64 tests pass
- [ ] Manual testing with Discord bot session transcripts

Co-Authored-By: Henry of Skalitz <henry.skalitz.seo@gmail.com>