### PR TITLE
feat: add Linux support for system vitals

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -700,17 +700,32 @@ async function refreshVitalsAsync() {
     temperature: null,
   };
 
+  // Detect platform for cross-platform support
+  const isLinux = process.platform === "linux";
+  const isMacOS = process.platform === "darwin";
+
   try {
+    // Platform-specific commands
+    const coresCmd = isLinux ? "nproc" : "sysctl -n hw.ncpu";
+    const memCmd = isLinux
+      ? "cat /proc/meminfo | grep MemTotal | awk '{print $2}'"
+      : "sysctl -n hw.memsize";
+    const topCmd = isLinux
+      ? "top -bn1 | head -3 | grep -E '^%?Cpu|^  ?CPU' || echo ''"
+      : 'top -l 1 -n 0 2>/dev/null | grep "CPU usage" || echo ""';
+
     // Run commands in parallel for speed
-    const [hostname, uptimeRaw, coresRaw, memTotalRaw, vmStatRaw, dfRaw, topOutput] =
+    const [hostname, uptimeRaw, coresRaw, memTotalRaw, memInfoRaw, dfRaw, topOutput] =
       await Promise.all([
         runCmd("hostname", { fallback: "unknown" }),
         runCmd("uptime", { fallback: "" }),
-        runCmd("sysctl -n hw.ncpu", { fallback: "1" }),
-        runCmd("sysctl -n hw.memsize", { fallback: "0" }),
-        runCmd("vm_stat", { fallback: "" }),
+        runCmd(coresCmd, { fallback: "1" }),
+        runCmd(memCmd, { fallback: "0" }),
+        isLinux
+          ? runCmd("cat /proc/meminfo", { fallback: "" })
+          : runCmd("vm_stat", { fallback: "" }),
         runCmd("df -k ~ | tail -1", { fallback: "" }),
-        runCmd('top -l 1 -n 0 2>/dev/null | grep "CPU usage" || echo ""', { fallback: "" }),
+        runCmd(topCmd, { fallback: "" }),
       ]);
 
     vitals.hostname = hostname;
@@ -729,13 +744,31 @@ async function refreshVitalsAsync() {
     // CPU
     vitals.cpu.cores = parseInt(coresRaw, 10) || 1;
     vitals.cpu.usage = Math.min(100, Math.round((vitals.cpu.loadAvg[0] / vitals.cpu.cores) * 100));
+
+    // Parse CPU usage from top (platform-specific)
     if (topOutput) {
-      const userMatch = topOutput.match(/([\d.]+)%\s*user/);
-      const sysMatch = topOutput.match(/([\d.]+)%\s*sys/);
-      vitals.cpu.userPercent = userMatch ? parseFloat(userMatch[1]) : null;
-      vitals.cpu.sysPercent = sysMatch ? parseFloat(sysMatch[1]) : null;
-      if (vitals.cpu.userPercent !== null && vitals.cpu.sysPercent !== null) {
-        vitals.cpu.usage = Math.round(vitals.cpu.userPercent + vitals.cpu.sysPercent);
+      if (isLinux) {
+        // Linux: %Cpu(s):  5.9 us,  2.0 sy,  0.0 ni, 91.5 id,  0.5 wa, ...
+        const userMatch = topOutput.match(/([\d.]+)\s*us/);
+        const sysMatch = topOutput.match(/([\d.]+)\s*sy/);
+        const idleMatch = topOutput.match(/([\d.]+)\s*id/);
+        vitals.cpu.userPercent = userMatch ? parseFloat(userMatch[1]) : null;
+        vitals.cpu.sysPercent = sysMatch ? parseFloat(sysMatch[1]) : null;
+        vitals.cpu.idlePercent = idleMatch ? parseFloat(idleMatch[1]) : null;
+        if (vitals.cpu.userPercent !== null && vitals.cpu.sysPercent !== null) {
+          vitals.cpu.usage = Math.round(vitals.cpu.userPercent + vitals.cpu.sysPercent);
+        }
+      } else {
+        // macOS: CPU usage: 5.9% user, 2.0% sys, 91.5% idle
+        const userMatch = topOutput.match(/([\d.]+)%\s*user/);
+        const sysMatch = topOutput.match(/([\d.]+)%\s*sys/);
+        const idleMatch = topOutput.match(/([\d.]+)%\s*idle/);
+        vitals.cpu.userPercent = userMatch ? parseFloat(userMatch[1]) : null;
+        vitals.cpu.sysPercent = sysMatch ? parseFloat(sysMatch[1]) : null;
+        vitals.cpu.idlePercent = idleMatch ? parseFloat(idleMatch[1]) : null;
+        if (vitals.cpu.userPercent !== null && vitals.cpu.sysPercent !== null) {
+          vitals.cpu.usage = Math.round(vitals.cpu.userPercent + vitals.cpu.sysPercent);
+        }
       }
     }
 
@@ -748,32 +781,71 @@ async function refreshVitalsAsync() {
       vitals.disk.percent = Math.round((parseInt(dfParts[2], 10) / parseInt(dfParts[1], 10)) * 100);
     }
 
-    // Memory
-    vitals.memory.total = parseInt(memTotalRaw, 10) || 0;
-    const pageSize = 16384;
-    const activePages = parseInt((vmStatRaw.match(/Pages active:\s+(\d+)/) || [])[1] || 0, 10);
-    const wiredPages = parseInt((vmStatRaw.match(/Pages wired down:\s+(\d+)/) || [])[1] || 0, 10);
-    const compressedPages = parseInt(
-      (vmStatRaw.match(/Pages occupied by compressor:\s+(\d+)/) || [])[1] || 0,
-      10,
-    );
-    vitals.memory.used = (activePages + wiredPages + compressedPages) * pageSize;
-    vitals.memory.free = vitals.memory.total - vitals.memory.used;
-    vitals.memory.percent =
-      vitals.memory.total > 0 ? Math.round((vitals.memory.used / vitals.memory.total) * 100) : 0;
+    // Memory (platform-specific)
+    if (isLinux) {
+      // Linux: parse /proc/meminfo
+      const memTotalKB = parseInt(memTotalRaw, 10) || 0;
+      const memAvailableMatch = memInfoRaw.match(/MemAvailable:\s+(\d+)/);
+      const memFreeMatch = memInfoRaw.match(/MemFree:\s+(\d+)/);
+
+      vitals.memory.total = memTotalKB * 1024;
+      const memAvailable = parseInt(memAvailableMatch?.[1] || memFreeMatch?.[1] || 0, 10) * 1024;
+
+      // On Linux, "used" = total - available (more accurate than total - free)
+      vitals.memory.used = vitals.memory.total - memAvailable;
+      vitals.memory.free = memAvailable;
+      vitals.memory.percent =
+        vitals.memory.total > 0 ? Math.round((vitals.memory.used / vitals.memory.total) * 100) : 0;
+    } else {
+      // macOS: parse vm_stat
+      const pageSize = 16384;
+      const activePages = parseInt((memInfoRaw.match(/Pages active:\s+(\d+)/) || [])[1] || 0, 10);
+      const wiredPages = parseInt(
+        (memInfoRaw.match(/Pages wired down:\s+(\d+)/) || [])[1] || 0,
+        10,
+      );
+      const compressedPages = parseInt(
+        (memInfoRaw.match(/Pages occupied by compressor:\s+(\d+)/) || [])[1] || 0,
+        10,
+      );
+      vitals.memory.total = parseInt(memTotalRaw, 10) || 0;
+      vitals.memory.used = (activePages + wiredPages + compressedPages) * pageSize;
+      vitals.memory.free = vitals.memory.total - vitals.memory.used;
+      vitals.memory.percent =
+        vitals.memory.total > 0 ? Math.round((vitals.memory.used / vitals.memory.total) * 100) : 0;
+    }
     vitals.memory.pressure =
       vitals.memory.percent > 90 ? "critical" : vitals.memory.percent > 75 ? "warning" : "normal";
 
-    // Secondary async calls (chip info, iostat)
+    // Secondary async calls (chip info, iostat) - macOS only for chip info
+    const iostatCmd = isLinux
+      ? "iostat -d 2 2>/dev/null | tail -1 || echo ''"
+      : "iostat -d -c 2 2>/dev/null | tail -1 || echo ''";
     const [perfCores, effCores, chip, iostatRaw] = await Promise.all([
-      runCmd("sysctl -n hw.perflevel0.logicalcpu 2>/dev/null || echo 0", { fallback: "0" }),
-      runCmd("sysctl -n hw.perflevel1.logicalcpu 2>/dev/null || echo 0", { fallback: "0" }),
-      runCmd(
-        'system_profiler SPHardwareDataType 2>/dev/null | grep "Chip:" | cut -d: -f2 || echo ""',
-        { fallback: "" },
-      ),
-      runCmd("iostat -d -c 2 2>/dev/null | tail -1 || echo ''", { fallback: "" }),
+      isMacOS
+        ? runCmd("sysctl -n hw.perflevel0.logicalcpu 2>/dev/null || echo 0", { fallback: "0" })
+        : Promise.resolve("0"),
+      isMacOS
+        ? runCmd("sysctl -n hw.perflevel1.logicalcpu 2>/dev/null || echo 0", { fallback: "0" })
+        : Promise.resolve("0"),
+      isMacOS
+        ? runCmd(
+            'system_profiler SPHardwareDataType 2>/dev/null | grep "Chip:" | cut -d: -f2 || echo ""',
+            { fallback: "" },
+          )
+        : Promise.resolve(""),
+      runCmd(iostatCmd, { fallback: "" }),
     ]);
+
+    // Get CPU brand on Linux
+    if (isLinux) {
+      const cpuBrand = await runCmd(
+        "cat /proc/cpuinfo | grep 'model name' | head -1 | cut -d: -f2",
+        { fallback: "" },
+      );
+      if (cpuBrand) vitals.cpu.brand = cpuBrand.trim();
+    }
+
     vitals.cpu.pCores = parseInt(perfCores, 10) || null;
     vitals.cpu.eCores = parseInt(effCores, 10) || null;
     if (chip) vitals.cpu.chip = chip;


### PR DESCRIPTION
## Summary

- Add cross-platform detection for system metrics on Linux
- Preserve all macOS-specific functionality

## Changes

### CPU
- Use `nproc` on Linux, `sysctl -n hw.ncpu` on macOS
- Parse Linux `top` output format (`us/sy/id` vs `user/sys/idle`)
- Get CPU brand from `/proc/cpuinfo` on Linux

### Memory
- Parse `/proc/meminfo` on Linux (MemTotal, MemAvailable, MemFree)
- Use "total - available" for more accurate Linux memory usage
- Preserve macOS `vm_stat` parsing

### I/O
- Use platform-specific `iostat` flags

## Test plan

- [x] All 64 tests pass
- [ ] Manual testing on Linux system

Co-Authored-By: Henry of Skalitz <henry.skalitz.seo@gmail.com>