### PR TITLE
feat: add profile-aware data directory with self-healing migration

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -127,7 +127,59 @@ function broadcastSSE(event, data) {
     sendSSE(client, event, data);
   }
 }
-const DATA_DIR = path.join(DASHBOARD_DIR, "data");
+
+// Profile-aware data directory (survives plugin updates)
+// Uses ~/.openclaw/command-center/data or ~/.openclaw-<profile>/command-center/data
+const DATA_DIR = path.join(getOpenClawDir(), "command-center", "data");
+const LEGACY_DATA_DIR = path.join(DASHBOARD_DIR, "data");
+
+/**
+ * Migrate data from legacy location to profile-aware location
+ * Runs once on startup, self-healing
+ */
+function migrateDataDir() {
+  try {
+    // Skip if legacy dir doesn't exist or new dir already has data
+    if (!fs.existsSync(LEGACY_DATA_DIR)) return;
+
+    // Ensure new data dir exists
+    if (!fs.existsSync(DATA_DIR)) {
+      fs.mkdirSync(DATA_DIR, { recursive: true });
+    }
+
+    // Check for files to migrate
+    const legacyFiles = fs.readdirSync(LEGACY_DATA_DIR);
+    if (legacyFiles.length === 0) return;
+
+    let migrated = 0;
+    for (const file of legacyFiles) {
+      const srcPath = path.join(LEGACY_DATA_DIR, file);
+      const destPath = path.join(DATA_DIR, file);
+
+      // Skip if destination already exists (don't overwrite)
+      if (fs.existsSync(destPath)) continue;
+
+      // Copy file to new location
+      const stat = fs.statSync(srcPath);
+      if (stat.isFile()) {
+        fs.copyFileSync(srcPath, destPath);
+        migrated++;
+        console.log(`[Migration] Copied ${file} to profile-aware data dir`);
+      }
+    }
+
+    if (migrated > 0) {
+      console.log(`[Migration] Migrated ${migrated} file(s) to ${DATA_DIR}`);
+      console.log(`[Migration] Legacy data preserved at ${LEGACY_DATA_DIR}`);
+    }
+  } catch (e) {
+    console.error("[Migration] Failed to migrate data:", e.message);
+    // Non-fatal - continue with new location
+  }
+}
+
+// Run migration on next tick (after module initialization)
+process.nextTick(migrateDataDir);
 
 // ============================================================================
 // PRIVACY SETTINGS


### PR DESCRIPTION
## Summary

- Move data directory to profile-aware location that survives plugin updates
- Add self-healing migration from legacy location

## Data Directory Locations

| Profile | Location |
|---------|----------|
| Default | `~/.openclaw/command-center/data` |
| Custom | `~/.openclaw-<profile>/command-center/data` |

## Features

- Uses `getOpenClawDir()` to respect `--profile` flag and `OPENCLAW_PROFILE`
- Supports multiple OpenClaw instances with separate data directories
- Self-healing migration runs on startup (`process.nextTick`)
- Copies files from legacy location without overwriting existing data
- Preserves legacy data at `public/data/` as backup

## Migration Behavior

1. On startup, checks if legacy `public/data/` exists
2. Creates new profile-aware data directory if needed
3. Copies any files not already in the new location
4. Logs migration progress
5. Preserves legacy files (non-destructive)

## Related

Based on work from PR #14 by @xtoor (Henry of Skalitz).

## Test plan

- [x] All 64 tests pass
- [ ] Manual testing with fresh install
- [ ] Manual testing with existing data migration
- [ ] Manual testing with multiple profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)