### PR TITLE
fix: ensure system paths in runCmd for LaunchAgent/cron environments

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -15,7 +15,15 @@ const execAsync = promisify(exec);
 
 // Helper to run command and return stdout (with timeout and error handling)
 async function runCmd(cmd, options = {}) {
-  const opts = { encoding: "utf8", timeout: 10000, ...options };
+  // Ensure standard system paths are available (LaunchAgent/cron may have minimal PATH)
+  const systemPath = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+  const envPath = process.env.PATH || "";
+  const opts = {
+    encoding: "utf8",
+    timeout: 10000,
+    env: { ...process.env, PATH: envPath.includes("/usr/sbin") ? envPath : `${systemPath}:${envPath}` },
+    ...options,
+  };
   try {
     const { stdout } = await execAsync(cmd, opts);
     return stdout.trim();


### PR DESCRIPTION
## Problem

When Command Center runs as a macOS LaunchAgent or Linux systemd service, the `PATH` environment variable is minimal (e.g., `/usr/bin:/bin` only). This causes system utilities like `sysctl` (located in `/usr/sbin`) to fail silently, with `runCmd` returning fallback values.

**Result:** System vitals show broken data — 0 cores, 0 B memory, unknown hostname.

## Fix

Prepend standard system paths (`/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`) to `PATH` in `runCmd` if `/usr/sbin` is not already present. This is a no-op when running interactively (PATH already includes these).

## Affected environments
- macOS LaunchAgent (confirmed)
- Linux systemd units (likely affected)
- Cron-launched instances (likely affected)
- Interactive/terminal usage: **no change**

## Testing
Tested on macOS 12.7.6 (Monterey) running CC via LaunchAgent. Before: vitals showed 1 core, 0 B memory. After: correct 4 cores, 16 GB memory.