### PR TITLE
fix: port temperature reading to async vitals + fix Intel Mac detection

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -855,7 +855,63 @@ async function refreshVitalsAsync() {
       vitals.disk.iops = parseFloat(iostatParts[1]) || 0;
       vitals.disk.throughputMBps = parseFloat(iostatParts[2]) || 0;
     }
-    vitals.temperatureNote = vitals.cpu.chip ? "Apple Silicon (requires elevated access)" : null;
+    // Temperature
+    vitals.temperature = null;
+    vitals.temperatureNote = null;
+    const isAppleSilicon = vitals.cpu.chip && /apple/i.test(vitals.cpu.chip);
+
+    if (isAppleSilicon) {
+      vitals.temperatureNote = "Apple Silicon (requires elevated access)";
+      try {
+        const pmOutput = await runCmd(
+          'sudo -n powermetrics --samplers smc -i 1 -n 1 2>/dev/null | grep -i "die temp" | head -1',
+          { fallback: "", timeout: 5000 }
+        );
+        const tempMatch = pmOutput.match(/([\d.]+)/);
+        if (tempMatch) {
+          vitals.temperature = parseFloat(tempMatch[1]);
+          vitals.temperatureNote = null;
+        }
+      } catch (e) {}
+    } else if (isMacOS) {
+      // Intel Mac: try osx-cpu-temp (tiny open-source SMC reader)
+      const home = require("os").homedir();
+      try {
+        const temp = await runCmd(
+          `osx-cpu-temp 2>/dev/null || ${home}/bin/osx-cpu-temp 2>/dev/null`,
+          { fallback: "" }
+        );
+        if (temp && temp.includes("\u00b0")) {
+          const tempMatch = temp.match(/([\d.]+)/);
+          if (tempMatch && parseFloat(tempMatch[1]) > 0) {
+            vitals.temperature = parseFloat(tempMatch[1]);
+          }
+        }
+      } catch (e) {}
+      // Fallback: battery temperature via ioreg
+      if (!vitals.temperature) {
+        try {
+          const ioregRaw = await runCmd(
+            'ioreg -r -n AppleSmartBattery 2>/dev/null | grep Temperature',
+            { fallback: "" }
+          );
+          const tempMatch = ioregRaw.match(/"Temperature"\s*=\s*(\d+)/);
+          if (tempMatch) {
+            vitals.temperature = Math.round(parseInt(tempMatch[1], 10) / 100);
+          }
+        } catch (e) {}
+      }
+    } else if (isLinux) {
+      try {
+        const temp = await runCmd(
+          'cat /sys/class/thermal/thermal_zone0/temp 2>/dev/null',
+          { fallback: "" }
+        );
+        if (temp) {
+          vitals.temperature = Math.round(parseInt(temp, 10) / 1000);
+        }
+      } catch (e) {}
+    }
   } catch (e) {
     console.error("[Vitals] Async refresh failed:", e.message);
   }
@@ -1088,7 +1144,7 @@ function getSystemVitalsOLD_DISABLED() {
     vitals.temperatureNote = null;
 
     // Check if Apple Silicon
-    const isAppleSilicon = vitals.cpu.chip || vitals.cpu.pCores;
+    const isAppleSilicon = vitals.cpu.chip && /apple/i.test(vitals.cpu.chip);
 
     if (isAppleSilicon) {
       // Apple Silicon: temperature requires sudo powermetrics


### PR DESCRIPTION
## Problems

### 1. Temperature always shows `null` / `- °C`
The temperature reading logic lives in `getSystemVitalsOLD_DISABLED()` — a function that is never called. The active `refreshVitalsAsync()` sets `temperatureNote` but never actually reads temperature sensors.

### 2. Apple Silicon detection is wrong on Intel Macs
`const isAppleSilicon = vitals.cpu.chip || vitals.cpu.pCores` — on Intel Macs, `hw.perflevel0.logicalcpu` returns the logical CPU count (e.g., 4), making `pCores` truthy. This causes Intel Macs to take the Apple Silicon code path (try `powermetrics`, skip `osx-cpu-temp`).

## Fixes

### Temperature ported to `refreshVitalsAsync()`
All three platform readers moved from the disabled function:
- **Apple Silicon:** `sudo -n powermetrics` (works when passwordless sudo configured)
- **Intel Mac:** `osx-cpu-temp` (open-source SMC reader, also checks `~/bin/`), with ioreg battery temp fallback
- **Linux:** `/sys/class/thermal/thermal_zone0/temp`

All use async `runCmd()` instead of blocking `execSync()`.

### Apple Silicon detection fixed
Changed to: `vitals.cpu.chip && /apple/i.test(vitals.cpu.chip)`
Only truthy when the chip is explicitly identified as Apple (e.g., "Apple M1").

## Testing
| Platform | Before | After |
|---|---|---|
| MBP 2015 Intel (macOS 12.7.6) | `- °C` | `62 °C` ✅ |
| Apple Silicon (macOS 14+) | `- °C` (dead code) | Should work if sudo -n configured |
| Linux | `- °C` (dead code) | Should work via thermal_zone |

## Note on `osx-cpu-temp`
This is a tiny MIT-licensed C binary ([lavoiesl/osx-cpu-temp](https://github.com/lavoiesl/osx-cpu-temp)) that reads Intel SMC sensors. It's not bundled — CC just tries to find it in PATH or `~/bin/`. If not installed, gracefully falls back to ioreg battery temp, then null.