### PR TITLE
fix: preserve local OpenClaw shim in dashboard launcher

### DIFF
--- a/scripts/run-server.sh
+++ b/scripts/run-server.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Wrapper script to ensure PATH includes system directories
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+# Wrapper script to ensure PATH includes the local OpenClaw shim and system directories.
+# nvm prepends its own bin directory when sourced, so set the final PATH after nvm loads.
 
 # Find node - prefer nvm if available
 if [ -f "$HOME/.nvm/nvm.sh" ]; then
     source "$HOME/.nvm/nvm.sh"
 fi
+
+export PATH="$HOME/.local/bin:$HOME/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
 cd "$(dirname "$0")/.."
 exec node lib/server.js


### PR DESCRIPTION
## Summary\n- move final PATH setup after nvm loads in scripts/run-server.sh\n- prefer ~/.local/bin and ~/bin so the dashboard uses the source-installed OpenClaw shim instead of an nvm global CLI\n\n## Test\n- npm test\n- verified command -v openclaw resolves to /Users/jontsai/.local/bin/openclaw after the launcher PATH setup\n\n## Context\nHeartbeat found the dashboard reachable only after a manual start, while async dashboard widgets logged config validation failures from the nvm global OpenClaw CLI. This launcher PATH ordering keeps the runtime on the intended local shim.