### PR TITLE
fix: reduce dashboard state refresh churn

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 var __getOwnPropNames = Object.getOwnPropertyNames;
 var __commonJS = (cb, mod) => function __require() {
-  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+  try {
+    return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+  } catch (e) {
+    throw mod = 0, e;
+  }
 };
 
 // src/utils.js
@@ -1392,7 +1396,7 @@ var require_sessions = __commonJS({
     function createSessionsModule2(deps) {
       const { getOpenClawDir: getOpenClawDir2, getOperatorBySlackId: getOperatorBySlackId2, runOpenClaw: runOpenClaw2, runOpenClawAsync: runOpenClawAsync2, extractJSON: extractJSON2 } = deps;
       let sessionsCache = { sessions: [], timestamp: 0, refreshing: false };
-      const SESSIONS_CACHE_TTL = 1e4;
+      const SESSIONS_CACHE_TTL = 6e4;
       function findTranscriptPath(sessionId) {
         if (!sessionId) return null;
         const openclawDir = getOpenClawDir2();
@@ -2925,7 +2929,21 @@ var require_state = __commonJS({
         }
         return activities.reverse();
       }
-      function getCapacity() {
+      function countActiveSessionsForCapacity(result, sessions2) {
+        const fiveMinMs = 5 * 60 * 1e3;
+        for (const s of sessions2) {
+          const ageMs = typeof s.ageMs === "number" ? s.ageMs : (s.minutesAgo || 0) * 60 * 1e3;
+          if (ageMs > fiveMinMs) continue;
+          const key = s.key || s.sessionKey || "";
+          if (key.includes(":subagent:") || key.includes(":cron:")) {
+            result.subagent.active++;
+          } else {
+            result.main.active++;
+          }
+        }
+        return result;
+      }
+      function getCapacity(preloadedSessions = null) {
         const result = {
           main: { active: 0, max: 12 },
           subagent: { active: 0, max: 24 }
@@ -2944,23 +2962,15 @@ var require_state = __commonJS({
           }
         } catch (e) {
         }
+        if (Array.isArray(preloadedSessions)) {
+          return countActiveSessionsForCapacity(result, preloadedSessions);
+        }
         try {
           const output = runOpenClaw2("sessions --json 2>/dev/null");
           const jsonStr = extractJSON2(output);
           if (jsonStr) {
             const data = JSON.parse(jsonStr);
-            const sessions2 = data.sessions || [];
-            const fiveMinMs = 5 * 60 * 1e3;
-            for (const s of sessions2) {
-              if (s.ageMs > fiveMinMs) continue;
-              const key = s.key || "";
-              if (key.includes(":subagent:") || key.includes(":cron:")) {
-                result.subagent.active++;
-              } else {
-                result.main.active++;
-              }
-            }
-            return result;
+            return countActiveSessionsForCapacity(result, data.sessions || []);
           }
         } catch (e) {
           console.error("Failed to get capacity from sessions, falling back to filesystem:", e.message);
@@ -3133,7 +3143,7 @@ var require_state = __commonJS({
           console.error("[State] vitals:", e.message);
         }
         try {
-          capacity = getCapacity();
+          capacity = getCapacity(allSessions);
         } catch (e) {
           console.error("[State] capacity:", e.message);
         }
@@ -3863,7 +3873,7 @@ server.listen(PORT, () => {
     }
     checkOptionalDeps();
   }, 100);
-  const SESSIONS_CACHE_TTL = 1e4;
+  const SESSIONS_CACHE_TTL = 6e4;
   setInterval(() => sessions.refreshSessionsCache(), SESSIONS_CACHE_TTL);
 });
 var sseRefreshing = false;
@@ -3871,7 +3881,7 @@ setInterval(() => {
   if (sseClients.size > 0 && !sseRefreshing) {
     sseRefreshing = true;
     try {
-      const fullState = state.refreshState();
+      const fullState = state.getFullState();
       broadcastSSE("update", fullState);
       broadcastSSE("heartbeat", { clients: sseClients.size, timestamp: Date.now() });
     } catch (e) {

--- a/src/index.js
+++ b/src/index.js
@@ -633,8 +633,9 @@ server.listen(PORT, () => {
     checkOptionalDeps();
   }, 100);
 
-  // Background cache refresh
-  const SESSIONS_CACHE_TTL = 10000;
+  // Background cache refresh. Keep this in sync with sessions.js; scanning transcript
+  // directories can be expensive on long-lived OpenClaw installs.
+  const SESSIONS_CACHE_TTL = 60000;
   setInterval(() => sessions.refreshSessionsCache(), SESSIONS_CACHE_TTL);
 });
 
@@ -644,7 +645,7 @@ setInterval(() => {
   if (sseClients.size > 0 && !sseRefreshing) {
     sseRefreshing = true;
     try {
-      const fullState = state.refreshState();
+      const fullState = state.getFullState();
       broadcastSSE("update", fullState);
       broadcastSSE("heartbeat", { clients: sseClients.size, timestamp: Date.now() });
     } catch (e) {

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -78,7 +78,7 @@ function createSessionsModule(deps) {
 
   // SESSION CACHE - Async refresh to avoid blocking
   let sessionsCache = { sessions: [], timestamp: 0, refreshing: false };
-  const SESSIONS_CACHE_TTL = 10000; // 10 seconds
+  const SESSIONS_CACHE_TTL = 60000; // 60 seconds - avoid rescanning large transcript dirs constantly
 
   /**
    * Find transcript file for a session ID.

--- a/src/state.js
+++ b/src/state.js
@@ -108,8 +108,34 @@ function createStateModule(deps) {
     return activities.reverse();
   }
 
+  function countActiveSessionsForCapacity(result, sessions) {
+    const fiveMinMs = 5 * 60 * 1000;
+
+    for (const s of sessions) {
+      // Only count sessions active in last 5 minutes.
+      // OpenClaw CLI sessions use ageMs/key; dashboard-mapped sessions use minutesAgo/sessionKey.
+      const ageMs = typeof s.ageMs === "number" ? s.ageMs : (s.minutesAgo || 0) * 60 * 1000;
+      if (ageMs > fiveMinMs) continue;
+
+      const key = s.key || s.sessionKey || "";
+      // Session key patterns:
+      //   agent:main:slack:... = main (human-initiated)
+      //   agent:main:telegram:... = main
+      //   agent:main:discord:... = main
+      //   agent:main:subagent:... = subagent (spawned task)
+      //   agent:main:cron:... = cron job (count as subagent)
+      if (key.includes(":subagent:") || key.includes(":cron:")) {
+        result.subagent.active++;
+      } else {
+        result.main.active++;
+      }
+    }
+
+    return result;
+  }
+
   // Get capacity info from gateway config and active sessions
-  function getCapacity() {
+  function getCapacity(preloadedSessions = null) {
     const result = {
       main: { active: 0, max: 12 },
       subagent: { active: 0, max: 24 },
@@ -134,33 +160,19 @@ function createStateModule(deps) {
       // Fall back to defaults
     }
 
+    // Reuse session data that getFullState already loaded so every dashboard state refresh
+    // does not invoke another `openclaw sessions --json` scan over large transcript dirs.
+    if (Array.isArray(preloadedSessions)) {
+      return countActiveSessionsForCapacity(result, preloadedSessions);
+    }
+
     // Try to get active counts from sessions (preferred - has full session keys)
     try {
       const output = runOpenClaw("sessions --json 2>/dev/null");
       const jsonStr = extractJSON(output);
       if (jsonStr) {
         const data = JSON.parse(jsonStr);
-        const sessions = data.sessions || [];
-        const fiveMinMs = 5 * 60 * 1000;
-
-        for (const s of sessions) {
-          // Only count sessions active in last 5 minutes
-          if (s.ageMs > fiveMinMs) continue;
-
-          const key = s.key || "";
-          // Session key patterns:
-          //   agent:main:slack:... = main (human-initiated)
-          //   agent:main:telegram:... = main
-          //   agent:main:discord:... = main
-          //   agent:main:subagent:... = subagent (spawned task)
-          //   agent:main:cron:... = cron job (count as subagent)
-          if (key.includes(":subagent:") || key.includes(":cron:")) {
-            result.subagent.active++;
-          } else {
-            result.main.active++;
-          }
-        }
-        return result;
+        return countActiveSessionsForCapacity(result, data.sessions || []);
       }
     } catch (e) {
       console.error("Failed to get capacity from sessions, falling back to filesystem:", e.message);
@@ -388,9 +400,10 @@ function createStateModule(deps) {
     } catch (e) {
       console.error("[State] vitals:", e.message);
     }
-    // Use filesystem-based capacity (no CLI calls, won't block)
+    // Reuse the session list already loaded above; otherwise this refresh performs a second
+    // expensive OpenClaw sessions scan and can stall the dashboard on large installations.
     try {
-      capacity = getCapacity();
+      capacity = getCapacity(allSessions);
     } catch (e) {
       console.error("[State] capacity:", e.message);
     }

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -1,0 +1,66 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { createStateModule } = require("../src/state");
+
+function createModule(overrides = {}) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "state-test-"));
+  fs.writeFileSync(
+    path.join(tmpDir, "openclaw.json"),
+    JSON.stringify({ agents: { defaults: { maxConcurrent: 12, subagents: { maxConcurrent: 24 } } } }),
+  );
+
+  return createStateModule({
+    CONFIG: { paths: { memory: path.join(tmpDir, "memory") }, billing: {} },
+    getOpenClawDir: () => tmpDir,
+    getSessions: () => [],
+    getSystemVitals: () => ({}),
+    getCronJobs: () => [],
+    loadOperators: () => ({ operators: [] }),
+    calculateOperatorStats: () => ({ operators: [], roles: {} }),
+    getLlmUsage: () => ({}),
+    getDailyTokenUsage: () => ({}),
+    getTokenStats: () => ({}),
+    getCerebroTopics: () => ({}),
+    runOpenClaw: () => {
+      throw new Error("runOpenClaw should not be called");
+    },
+    extractJSON: () => null,
+    readTranscript: () => [],
+    ...overrides,
+  });
+}
+
+test("getCapacity uses preloaded sessions without invoking OpenClaw CLI", () => {
+  const state = createModule();
+
+  const capacity = state.getCapacity([
+    { sessionKey: "agent:main:slack:C123", minutesAgo: 1 },
+    { sessionKey: "agent:main:cron:heartbeat", minutesAgo: 2 },
+    { sessionKey: "agent:main:subagent:abc", minutesAgo: 4 },
+    { sessionKey: "agent:main:slack:old", minutesAgo: 10 },
+  ]);
+
+  assert.deepEqual(capacity, {
+    main: { active: 1, max: 12 },
+    subagent: { active: 2, max: 24 },
+  });
+});
+
+test("getCapacity still supports raw OpenClaw session objects when preloaded", () => {
+  const state = createModule();
+
+  const capacity = state.getCapacity([
+    { key: "agent:main:telegram:chat", ageMs: 1000 },
+    { key: "agent:main:subagent:worker", ageMs: 2000 },
+    { key: "agent:main:cron:job", ageMs: 10 * 60 * 1000 },
+  ]);
+
+  assert.deepEqual(capacity, {
+    main: { active: 1, max: 12 },
+    subagent: { active: 1, max: 24 },
+  });
+});


### PR DESCRIPTION
## Summary\n- reuse preloaded session data when computing capacity during full dashboard state refresh\n- stop forcing SSE heartbeats to bypass the state cache\n- lengthen the session cache refresh interval from 10s to 60s for large transcript directories\n- add regression coverage for capacity counts from preloaded sessions\n\n## Validation\n- npm test\n- npm run lint (passes with existing warnings)\n- npm run build\n- git diff --check\n- local test server on :4333 returned /api/state in 0.015s then sub-5ms cached responses\n\n## Context\nHeartbeat diagnostics found two local dashboard processes holding ~80-95% CPU and intermittent /api/state latency up to ~8s on an install with ~52k session transcripts / 7.8GB under ~/.openclaw/agents/main/sessions. Sampling pointed at heavy sorting/scanning in the session path. This reduces repeated session scans in the dashboard hot path.