### PR TITLE
fix: index transcript paths for session cache

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1392,117 +1392,169 @@ var require_sessions = __commonJS({
     function createSessionsModule2(deps) {
       const { getOpenClawDir: getOpenClawDir2, getOperatorBySlackId: getOperatorBySlackId2, runOpenClaw: runOpenClaw2, runOpenClawAsync: runOpenClawAsync2, extractJSON: extractJSON2 } = deps;
       let sessionsCache = { sessions: [], timestamp: 0, refreshing: false };
-      const SESSIONS_CACHE_TTL = 1e4;
-      function findTranscriptPath(sessionId) {
-        if (!sessionId) return null;
+      const SESSIONS_CACHE_TTL = 6e4;
+      const transcriptMetadataCache = /* @__PURE__ */ new Map();
+      let transcriptPathIndex = null;
+      let transcriptPathIndexTimestamp = 0;
+      const TRANSCRIPT_PATH_INDEX_TTL = 3e5;
+      function getSessionsDir() {
         const openclawDir = getOpenClawDir2();
-        const sessionsDir = path2.join(openclawDir, "agents", "main", "sessions");
-        const exactPath = path2.join(sessionsDir, `${sessionId}.jsonl`);
-        if (fs2.existsSync(exactPath)) return exactPath;
+        return path2.join(openclawDir, "agents", "main", "sessions");
+      }
+      function getBaseSessionIdFromTranscriptFile(file) {
+        if (!file.endsWith(".jsonl") || file.includes(".deleted.")) return null;
+        const name = file.slice(0, -".jsonl".length);
+        const exactUuidMatch = name.match(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+        );
+        if (exactUuidMatch) return { sessionId: name, exact: true };
+        const suffixedUuidMatch = name.match(
+          /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-/i
+        );
+        if (suffixedUuidMatch) return { sessionId: suffixedUuidMatch[1], exact: false };
+        return { sessionId: name, exact: true };
+      }
+      function getTranscriptPathIndex() {
+        const now = Date.now();
+        if (transcriptPathIndex && now - transcriptPathIndexTimestamp < TRANSCRIPT_PATH_INDEX_TTL) {
+          return transcriptPathIndex;
+        }
+        const sessionsDir = getSessionsDir();
+        const index = /* @__PURE__ */ new Map();
         try {
           const files = fs2.readdirSync(sessionsDir);
-          const prefix = `${sessionId}-`;
-          const match = files.find(
-            (f) => f.startsWith(prefix) && f.endsWith(".jsonl") && !f.includes(".deleted.")
-          );
-          if (match) return path2.join(sessionsDir, match);
+          for (const file of files) {
+            const transcript = getBaseSessionIdFromTranscriptFile(file);
+            if (!transcript) continue;
+            if (!index.has(transcript.sessionId) || transcript.exact) {
+              index.set(transcript.sessionId, path2.join(sessionsDir, file));
+            }
+          }
         } catch (e) {
+        }
+        transcriptPathIndex = index;
+        transcriptPathIndexTimestamp = now;
+        return transcriptPathIndex;
+      }
+      function findTranscriptPath(sessionId) {
+        if (!sessionId) return null;
+        const exactPath = path2.join(getSessionsDir(), `${sessionId}.jsonl`);
+        if (fs2.existsSync(exactPath)) return exactPath;
+        return getTranscriptPathIndex().get(sessionId) || null;
+      }
+      function readTranscriptPrefix(transcriptPath, maxBytes = 5e4) {
+        const fd = fs2.openSync(transcriptPath, "r");
+        try {
+          const buffer = Buffer.alloc(maxBytes);
+          const bytesRead = fs2.readSync(fd, buffer, 0, maxBytes, 0);
+          return buffer.toString("utf8", 0, bytesRead);
+        } finally {
+          fs2.closeSync(fd);
+        }
+      }
+      function extractOriginatorFromLines(lines) {
+        for (let i = 0; i < Math.min(lines.length, 10); i++) {
+          try {
+            const entry = JSON.parse(lines[i]);
+            if (entry.type !== "message" || !entry.message) continue;
+            const msg = entry.message;
+            if (msg.role !== "user") continue;
+            let text = "";
+            if (typeof msg.content === "string") {
+              text = msg.content;
+            } else if (Array.isArray(msg.content)) {
+              const textPart = msg.content.find((c) => c.type === "text");
+              if (textPart) text = textPart.text || "";
+            }
+            if (!text) continue;
+            const slackUserMatch = text.match(/\]\s*([\w.-]+)\s*\(([A-Z0-9]+)\):/);
+            if (slackUserMatch) {
+              const username = slackUserMatch[1];
+              const userId = slackUserMatch[2];
+              const operator = getOperatorBySlackId2(userId);
+              return {
+                userId,
+                username,
+                displayName: operator?.name || username,
+                role: operator?.role || "user",
+                avatar: operator?.avatar || null
+              };
+            }
+            const senderIdMatch = text.match(/"sender_id":\s*"([A-Z0-9]+)"/);
+            const senderMatch = text.match(/"sender":\s*"([^"]+)"/);
+            if (senderIdMatch) {
+              const userId = senderIdMatch[1];
+              const username = senderMatch ? senderMatch[1] : userId;
+              const operator = getOperatorBySlackId2(userId);
+              return {
+                userId,
+                username,
+                displayName: operator?.name || username,
+                role: operator?.role || "user",
+                avatar: operator?.avatar || null
+              };
+            }
+          } catch (e) {
+          }
         }
         return null;
       }
-      function getSessionOriginator(sessionId) {
-        try {
-          if (!sessionId) return null;
-          const transcriptPath = findTranscriptPath(sessionId);
-          if (!transcriptPath) return null;
-          const content = fs2.readFileSync(transcriptPath, "utf8");
-          const lines = content.trim().split("\n");
-          for (let i = 0; i < Math.min(lines.length, 10); i++) {
-            try {
-              const entry = JSON.parse(lines[i]);
-              if (entry.type !== "message" || !entry.message) continue;
-              const msg = entry.message;
-              if (msg.role !== "user") continue;
-              let text = "";
-              if (typeof msg.content === "string") {
-                text = msg.content;
-              } else if (Array.isArray(msg.content)) {
-                const textPart = msg.content.find((c) => c.type === "text");
-                if (textPart) text = textPart.text || "";
+      function extractTopicFromLines(lines) {
+        let textSamples = [];
+        for (const line of lines.slice(0, 30)) {
+          try {
+            const entry = JSON.parse(line);
+            if (entry.type === "message" && entry.message?.content) {
+              const msgContent = entry.message.content;
+              if (Array.isArray(msgContent)) {
+                msgContent.forEach((c) => {
+                  if (c.type === "text" && c.text) {
+                    textSamples.push(c.text.slice(0, 500));
+                  }
+                });
+              } else if (typeof msgContent === "string") {
+                textSamples.push(msgContent.slice(0, 500));
               }
-              if (!text) continue;
-              const slackUserMatch = text.match(/\]\s*([\w.-]+)\s*\(([A-Z0-9]+)\):/);
-              if (slackUserMatch) {
-                const username = slackUserMatch[1];
-                const userId = slackUserMatch[2];
-                const operator = getOperatorBySlackId2(userId);
-                return {
-                  userId,
-                  username,
-                  displayName: operator?.name || username,
-                  role: operator?.role || "user",
-                  avatar: operator?.avatar || null
-                };
-              }
-              const senderIdMatch = text.match(/"sender_id":\s*"([A-Z0-9]+)"/);
-              const senderMatch = text.match(/"sender":\s*"([^"]+)"/);
-              if (senderIdMatch) {
-                const userId = senderIdMatch[1];
-                const username = senderMatch ? senderMatch[1] : userId;
-                const operator = getOperatorBySlackId2(userId);
-                return {
-                  userId,
-                  username,
-                  displayName: operator?.name || username,
-                  role: operator?.role || "user",
-                  avatar: operator?.avatar || null
-                };
-              }
-            } catch (e) {
             }
+          } catch (e) {
           }
-          return null;
+        }
+        if (textSamples.length === 0) return null;
+        const topics = detectTopics(textSamples.join(" "));
+        return topics.length > 0 ? topics.slice(0, 2).join(", ") : null;
+      }
+      function getSessionMetadata(sessionId) {
+        if (!sessionId) return { originator: null, topic: null };
+        try {
+          const transcriptPath = findTranscriptPath(sessionId);
+          if (!transcriptPath) return { originator: null, topic: null };
+          const stat = fs2.statSync(transcriptPath);
+          const cached = transcriptMetadataCache.get(sessionId);
+          if (cached && cached.transcriptPath === transcriptPath && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+            return cached.metadata;
+          }
+          const content = readTranscriptPrefix(transcriptPath, 5e4);
+          const lines = content.split("\n").filter((l) => l.trim());
+          const metadata = {
+            originator: extractOriginatorFromLines(lines),
+            topic: extractTopicFromLines(lines)
+          };
+          transcriptMetadataCache.set(sessionId, {
+            transcriptPath,
+            mtimeMs: stat.mtimeMs,
+            size: stat.size,
+            metadata
+          });
+          return metadata;
         } catch (e) {
-          return null;
+          return { originator: null, topic: null };
         }
       }
+      function getSessionOriginator(sessionId) {
+        return getSessionMetadata(sessionId).originator;
+      }
       function getSessionTopic(sessionId) {
-        if (!sessionId) return null;
-        try {
-          const transcriptPath = findTranscriptPath(sessionId);
-          if (!transcriptPath) return null;
-          const fd = fs2.openSync(transcriptPath, "r");
-          const buffer = Buffer.alloc(5e4);
-          const bytesRead = fs2.readSync(fd, buffer, 0, 5e4, 0);
-          fs2.closeSync(fd);
-          if (bytesRead === 0) return null;
-          const content = buffer.toString("utf8", 0, bytesRead);
-          const lines = content.split("\n").filter((l) => l.trim());
-          let textSamples = [];
-          for (const line of lines.slice(0, 30)) {
-            try {
-              const entry = JSON.parse(line);
-              if (entry.type === "message" && entry.message?.content) {
-                const msgContent = entry.message.content;
-                if (Array.isArray(msgContent)) {
-                  msgContent.forEach((c) => {
-                    if (c.type === "text" && c.text) {
-                      textSamples.push(c.text.slice(0, 500));
-                    }
-                  });
-                } else if (typeof msgContent === "string") {
-                  textSamples.push(msgContent.slice(0, 500));
-                }
-              }
-            } catch (e) {
-            }
-          }
-          if (textSamples.length === 0) return null;
-          const topics = detectTopics(textSamples.join(" "));
-          return topics.length > 0 ? topics.slice(0, 2).join(", ") : null;
-        } catch (e) {
-          return null;
-        }
+        return getSessionMetadata(sessionId).topic;
       }
       function mapSession(s) {
         const minutesAgo = s.ageMs ? s.ageMs / 6e4 : Infinity;
@@ -1516,9 +1568,10 @@ var require_sessions = __commonJS({
         if (s.key.includes(":subagent:")) sessionType = "subagent";
         else if (s.key.includes(":cron:")) sessionType = "cron";
         else if (s.key === "agent:main:main") sessionType = "main";
-        const originator = getSessionOriginator(s.sessionId);
+        const metadata = getSessionMetadata(s.sessionId);
+        const originator = metadata.originator;
         const label = s.groupChannel || s.displayName || parseSessionLabel(s.key);
-        const topic = getSessionTopic(s.sessionId);
+        const topic = metadata.topic;
         const totalTokens = s.totalTokens || 0;
         const sessionAgeMinutes = Math.max(1, Math.min(minutesAgo, 24 * 60));
         const burnRate = Math.round(totalTokens / sessionAgeMinutes);
@@ -2118,10 +2171,42 @@ var require_tokens = __commonJS({
       // $18.75/1M (25% premium on input)
     };
     var tokenUsageCache = { data: null, timestamp: 0, refreshing: false };
-    var TOKEN_USAGE_CACHE_TTL = 3e4;
+    var TOKEN_USAGE_CACHE_TTL = 3e5;
+    var tokenUsageFileCache = /* @__PURE__ */ new Map();
     var refreshInterval = null;
     function emptyUsageBucket() {
       return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, requests: 0 };
+    }
+    function addUsageToBucket(bucket, usage) {
+      bucket.input += usage.input;
+      bucket.output += usage.output;
+      bucket.cacheRead += usage.cacheRead;
+      bucket.cacheWrite += usage.cacheWrite;
+      bucket.cost += usage.cost;
+      bucket.requests++;
+    }
+    function collectTokenUsageEvents(content, sevenDaysAgo) {
+      const events = [];
+      const lines = content.trim().split("\n");
+      for (const line of lines) {
+        if (!line) continue;
+        try {
+          const entry = JSON.parse(line);
+          const entryTime = entry.timestamp ? new Date(entry.timestamp).getTime() : 0;
+          if (entryTime < sevenDaysAgo || !entry.message?.usage) continue;
+          const u = entry.message.usage;
+          events.push({
+            time: entryTime,
+            input: u.input || 0,
+            output: u.output || 0,
+            cacheRead: u.cacheRead || 0,
+            cacheWrite: u.cacheWrite || 0,
+            cost: u.cost?.total || 0
+          });
+        } catch (e) {
+        }
+      }
+      return events;
     }
     async function refreshTokenUsageAsync2(getOpenClawDir2) {
       if (tokenUsageCache.refreshing) return;
@@ -2137,61 +2222,46 @@ var require_tokens = __commonJS({
         const usage24h = emptyUsageBucket();
         const usage3d = emptyUsageBucket();
         const usage7d = emptyUsageBucket();
+        const seenFiles = /* @__PURE__ */ new Set();
         const batchSize = 50;
         for (let i = 0; i < jsonlFiles.length; i += batchSize) {
           const batch = jsonlFiles.slice(i, i + batchSize);
           await Promise.all(
             batch.map(async (file) => {
               const filePath = path2.join(sessionsDir, file);
+              seenFiles.add(filePath);
               try {
                 const stat = await fs2.promises.stat(filePath);
-                if (stat.mtimeMs < sevenDaysAgo) return;
-                const content = await fs2.promises.readFile(filePath, "utf8");
-                const lines = content.trim().split("\n");
-                for (const line of lines) {
-                  if (!line) continue;
-                  try {
-                    const entry = JSON.parse(line);
-                    const entryTime = entry.timestamp ? new Date(entry.timestamp).getTime() : 0;
-                    if (entryTime < sevenDaysAgo) continue;
-                    if (entry.message?.usage) {
-                      const u = entry.message.usage;
-                      const input = u.input || 0;
-                      const output = u.output || 0;
-                      const cacheRead = u.cacheRead || 0;
-                      const cacheWrite = u.cacheWrite || 0;
-                      const cost = u.cost?.total || 0;
-                      if (entryTime >= oneDayAgo) {
-                        usage24h.input += input;
-                        usage24h.output += output;
-                        usage24h.cacheRead += cacheRead;
-                        usage24h.cacheWrite += cacheWrite;
-                        usage24h.cost += cost;
-                        usage24h.requests++;
-                      }
-                      if (entryTime >= threeDaysAgo) {
-                        usage3d.input += input;
-                        usage3d.output += output;
-                        usage3d.cacheRead += cacheRead;
-                        usage3d.cacheWrite += cacheWrite;
-                        usage3d.cost += cost;
-                        usage3d.requests++;
-                      }
-                      usage7d.input += input;
-                      usage7d.output += output;
-                      usage7d.cacheRead += cacheRead;
-                      usage7d.cacheWrite += cacheWrite;
-                      usage7d.cost += cost;
-                      usage7d.requests++;
-                    }
-                  } catch (e) {
-                  }
+                if (stat.mtimeMs < sevenDaysAgo) {
+                  tokenUsageFileCache.delete(filePath);
+                  return;
+                }
+                const cached = tokenUsageFileCache.get(filePath);
+                let events = cached?.events;
+                if (!cached || cached.mtimeMs !== stat.mtimeMs || cached.size !== stat.size) {
+                  const content = await fs2.promises.readFile(filePath, "utf8");
+                  events = collectTokenUsageEvents(content, sevenDaysAgo);
+                  tokenUsageFileCache.set(filePath, {
+                    mtimeMs: stat.mtimeMs,
+                    size: stat.size,
+                    events
+                  });
+                }
+                for (const event of events) {
+                  if (event.time < sevenDaysAgo) continue;
+                  if (event.time >= oneDayAgo) addUsageToBucket(usage24h, event);
+                  if (event.time >= threeDaysAgo) addUsageToBucket(usage3d, event);
+                  addUsageToBucket(usage7d, event);
                 }
               } catch (e) {
+                tokenUsageFileCache.delete(filePath);
               }
             })
           );
           await new Promise((resolve) => setImmediate(resolve));
+        }
+        for (const filePath of tokenUsageFileCache.keys()) {
+          if (!seenFiles.has(filePath)) tokenUsageFileCache.delete(filePath);
         }
         const finalizeBucket = (bucket) => ({
           ...bucket,
@@ -2462,6 +2532,7 @@ var require_tokens = __commonJS({
     module2.exports = {
       TOKEN_RATES,
       emptyUsageBucket,
+      collectTokenUsageEvents,
       refreshTokenUsageAsync: refreshTokenUsageAsync2,
       getDailyTokenUsage: getDailyTokenUsage2,
       calculateCostForBucket,
@@ -3863,7 +3934,7 @@ server.listen(PORT, () => {
     }
     checkOptionalDeps();
   }, 100);
-  const SESSIONS_CACHE_TTL = 1e4;
+  const SESSIONS_CACHE_TTL = sessions.SESSIONS_CACHE_TTL || 6e4;
   setInterval(() => sessions.refreshSessionsCache(), SESSIONS_CACHE_TTL);
 });
 var sseRefreshing = false;

--- a/scripts/run-server.sh
+++ b/scripts/run-server.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Wrapper script to ensure PATH includes system directories
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+# Wrapper script to ensure PATH includes the local OpenClaw shim and system directories.
+# nvm prepends its own bin directory when sourced, so set the final PATH after nvm loads.
 
 # Find node - prefer nvm if available
 if [ -f "$HOME/.nvm/nvm.sh" ]; then
     source "$HOME/.nvm/nvm.sh"
 fi
+
+export PATH="$HOME/.local/bin:$HOME/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
 cd "$(dirname "$0")/.."
 exec node lib/server.js

--- a/src/index.js
+++ b/src/index.js
@@ -634,7 +634,7 @@ server.listen(PORT, () => {
   }, 100);
 
   // Background cache refresh
-  const SESSIONS_CACHE_TTL = 10000;
+  const SESSIONS_CACHE_TTL = sessions.SESSIONS_CACHE_TTL || 60000;
   setInterval(() => sessions.refreshSessionsCache(), SESSIONS_CACHE_TTL);
 });
 

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -78,7 +78,67 @@ function createSessionsModule(deps) {
 
   // SESSION CACHE - Async refresh to avoid blocking
   let sessionsCache = { sessions: [], timestamp: 0, refreshing: false };
-  const SESSIONS_CACHE_TTL = 10000; // 10 seconds
+  const SESSIONS_CACHE_TTL = 60000; // 1 minute
+  const transcriptMetadataCache = new Map();
+  let transcriptPathIndex = null;
+  let transcriptPathIndexTimestamp = 0;
+  const TRANSCRIPT_PATH_INDEX_TTL = 300000; // 5 minutes
+
+  function getSessionsDir() {
+    const openclawDir = getOpenClawDir();
+    return path.join(openclawDir, "agents", "main", "sessions");
+  }
+
+  function getBaseSessionIdFromTranscriptFile(file) {
+    if (!file.endsWith(".jsonl") || file.includes(".deleted.")) return null;
+
+    const name = file.slice(0, -".jsonl".length);
+
+    // Plain transcript: <sessionId>.jsonl
+    const exactUuidMatch = name.match(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+    if (exactUuidMatch) return { sessionId: name, exact: true };
+
+    // Suffix transcript: <sessionId>-topic-...jsonl, <sessionId>-...jsonl, etc.
+    // This preserves the previous fallback semantics without scanning the whole directory
+    // once for every missing exact match.
+    const suffixedUuidMatch = name.match(
+      /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-/i,
+    );
+    if (suffixedUuidMatch) return { sessionId: suffixedUuidMatch[1], exact: false };
+
+    return { sessionId: name, exact: true };
+  }
+
+  function getTranscriptPathIndex() {
+    const now = Date.now();
+    if (transcriptPathIndex && now - transcriptPathIndexTimestamp < TRANSCRIPT_PATH_INDEX_TTL) {
+      return transcriptPathIndex;
+    }
+
+    const sessionsDir = getSessionsDir();
+    const index = new Map();
+
+    try {
+      const files = fs.readdirSync(sessionsDir);
+      for (const file of files) {
+        const transcript = getBaseSessionIdFromTranscriptFile(file);
+        if (!transcript) continue;
+
+        // Prefer exact transcript names over suffixed fallbacks.
+        if (!index.has(transcript.sessionId) || transcript.exact) {
+          index.set(transcript.sessionId, path.join(sessionsDir, file));
+        }
+      }
+    } catch (e) {
+      // Directory read failed; keep an empty index for this TTL window.
+    }
+
+    transcriptPathIndex = index;
+    transcriptPathIndexTimestamp = now;
+    return transcriptPathIndex;
+  }
 
   /**
    * Find transcript file for a session ID.
@@ -89,104 +149,162 @@ function createSessionsModule(deps) {
   function findTranscriptPath(sessionId) {
     if (!sessionId) return null;
 
-    const openclawDir = getOpenClawDir();
-    const sessionsDir = path.join(openclawDir, "agents", "main", "sessions");
-
-    // Try exact match first (most common case)
-    const exactPath = path.join(sessionsDir, `${sessionId}.jsonl`);
+    // Exact transcript names are cheap to check and should become visible immediately.
+    // Keep the expensive directory-wide fallback index for topic-suffixed legacy files.
+    const exactPath = path.join(getSessionsDir(), `${sessionId}.jsonl`);
     if (fs.existsSync(exactPath)) return exactPath;
 
-    // Search for topic-suffixed files (e.g., sessionId-topic-TIMESTAMP.jsonl)
+    return getTranscriptPathIndex().get(sessionId) || null;
+  }
+
+  function readTranscriptPrefix(transcriptPath, maxBytes = 50000) {
+    const fd = fs.openSync(transcriptPath, "r");
     try {
-      const files = fs.readdirSync(sessionsDir);
-      const prefix = `${sessionId}-`;
-      const match = files.find(
-        (f) => f.startsWith(prefix) && f.endsWith(".jsonl") && !f.includes(".deleted."),
-      );
-      if (match) return path.join(sessionsDir, match);
-    } catch (e) {
-      // Directory read failed
+      const buffer = Buffer.alloc(maxBytes);
+      const bytesRead = fs.readSync(fd, buffer, 0, maxBytes, 0);
+      return buffer.toString("utf8", 0, bytesRead);
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+
+  function extractOriginatorFromLines(lines) {
+    // Find the first user message to extract originator
+    for (let i = 0; i < Math.min(lines.length, 10); i++) {
+      try {
+        const entry = JSON.parse(lines[i]);
+        if (entry.type !== "message" || !entry.message) continue;
+
+        const msg = entry.message;
+        if (msg.role !== "user") continue;
+
+        let text = "";
+        if (typeof msg.content === "string") {
+          text = msg.content;
+        } else if (Array.isArray(msg.content)) {
+          const textPart = msg.content.find((c) => c.type === "text");
+          if (textPart) text = textPart.text || "";
+        }
+
+        if (!text) continue;
+
+        // Extract Slack user from message patterns:
+        // Format 1 (old): "[Slack #channel +6m 2026-01-27 15:31 PST] username (USERID): message"
+        // Format 2 (new): Conversation info JSON with "sender_id": "USERID" and "sender": "username"
+        const slackUserMatch = text.match(/\]\s*([\w.-]+)\s*\(([A-Z0-9]+)\):/);
+
+        if (slackUserMatch) {
+          const username = slackUserMatch[1];
+          const userId = slackUserMatch[2];
+
+          const operator = getOperatorBySlackId(userId);
+
+          return {
+            userId,
+            username,
+            displayName: operator?.name || username,
+            role: operator?.role || "user",
+            avatar: operator?.avatar || null,
+          };
+        }
+
+        // Try new format: Conversation info JSON block
+        // Look for "sender_id": "USERID" and "sender": "username"
+        const senderIdMatch = text.match(/"sender_id":\s*"([A-Z0-9]+)"/);
+        const senderMatch = text.match(/"sender":\s*"([^"]+)"/);
+
+        if (senderIdMatch) {
+          const userId = senderIdMatch[1];
+          const username = senderMatch ? senderMatch[1] : userId;
+
+          const operator = getOperatorBySlackId(userId);
+
+          return {
+            userId,
+            username,
+            displayName: operator?.name || username,
+            role: operator?.role || "user",
+            avatar: operator?.avatar || null,
+          };
+        }
+      } catch (e) {}
     }
 
     return null;
   }
 
-  // Extract session originator from transcript
-  function getSessionOriginator(sessionId) {
+  function extractTopicFromLines(lines) {
+    // Extract text from messages
+    // Transcript format: {type: "message", message: {role: "user"|"assistant", content: [...]}}
+    let textSamples = [];
+    for (const line of lines.slice(0, 30)) {
+      // First 30 entries
+      try {
+        const entry = JSON.parse(line);
+        if (entry.type === "message" && entry.message?.content) {
+          const msgContent = entry.message.content;
+          if (Array.isArray(msgContent)) {
+            msgContent.forEach((c) => {
+              if (c.type === "text" && c.text) {
+                textSamples.push(c.text.slice(0, 500));
+              }
+            });
+          } else if (typeof msgContent === "string") {
+            textSamples.push(msgContent.slice(0, 500));
+          }
+        }
+      } catch (e) {
+        /* skip malformed lines */
+      }
+    }
+
+    if (textSamples.length === 0) return null;
+
+    const topics = detectTopics(textSamples.join(" "));
+    return topics.length > 0 ? topics.slice(0, 2).join(", ") : null;
+  }
+
+  function getSessionMetadata(sessionId) {
+    if (!sessionId) return { originator: null, topic: null };
+
     try {
-      if (!sessionId) return null;
-
       const transcriptPath = findTranscriptPath(sessionId);
-      if (!transcriptPath) return null;
+      if (!transcriptPath) return { originator: null, topic: null };
 
-      const content = fs.readFileSync(transcriptPath, "utf8");
-      const lines = content.trim().split("\n");
-
-      // Find the first user message to extract originator
-      for (let i = 0; i < Math.min(lines.length, 10); i++) {
-        try {
-          const entry = JSON.parse(lines[i]);
-          if (entry.type !== "message" || !entry.message) continue;
-
-          const msg = entry.message;
-          if (msg.role !== "user") continue;
-
-          let text = "";
-          if (typeof msg.content === "string") {
-            text = msg.content;
-          } else if (Array.isArray(msg.content)) {
-            const textPart = msg.content.find((c) => c.type === "text");
-            if (textPart) text = textPart.text || "";
-          }
-
-          if (!text) continue;
-
-          // Extract Slack user from message patterns:
-          // Format 1 (old): "[Slack #channel +6m 2026-01-27 15:31 PST] username (USERID): message"
-          // Format 2 (new): Conversation info JSON with "sender_id": "USERID" and "sender": "username"
-          const slackUserMatch = text.match(/\]\s*([\w.-]+)\s*\(([A-Z0-9]+)\):/);
-
-          if (slackUserMatch) {
-            const username = slackUserMatch[1];
-            const userId = slackUserMatch[2];
-
-            const operator = getOperatorBySlackId(userId);
-
-            return {
-              userId,
-              username,
-              displayName: operator?.name || username,
-              role: operator?.role || "user",
-              avatar: operator?.avatar || null,
-            };
-          }
-
-          // Try new format: Conversation info JSON block
-          // Look for "sender_id": "USERID" and "sender": "username"
-          const senderIdMatch = text.match(/"sender_id":\s*"([A-Z0-9]+)"/);
-          const senderMatch = text.match(/"sender":\s*"([^"]+)"/);
-
-          if (senderIdMatch) {
-            const userId = senderIdMatch[1];
-            const username = senderMatch ? senderMatch[1] : userId;
-
-            const operator = getOperatorBySlackId(userId);
-
-            return {
-              userId,
-              username,
-              displayName: operator?.name || username,
-              role: operator?.role || "user",
-              avatar: operator?.avatar || null,
-            };
-          }
-        } catch (e) {}
+      const stat = fs.statSync(transcriptPath);
+      const cached = transcriptMetadataCache.get(sessionId);
+      if (
+        cached &&
+        cached.transcriptPath === transcriptPath &&
+        cached.mtimeMs === stat.mtimeMs &&
+        cached.size === stat.size
+      ) {
+        return cached.metadata;
       }
 
-      return null;
+      // Read first 50KB of transcript once per file version; enough for originator/topic.
+      const content = readTranscriptPrefix(transcriptPath, 50000);
+      const lines = content.split("\n").filter((l) => l.trim());
+      const metadata = {
+        originator: extractOriginatorFromLines(lines),
+        topic: extractTopicFromLines(lines),
+      };
+
+      transcriptMetadataCache.set(sessionId, {
+        transcriptPath,
+        mtimeMs: stat.mtimeMs,
+        size: stat.size,
+        metadata,
+      });
+      return metadata;
     } catch (e) {
-      return null;
+      return { originator: null, topic: null };
     }
+  }
+
+  // Extract session originator from transcript
+  function getSessionOriginator(sessionId) {
+    return getSessionMetadata(sessionId).originator;
   }
 
   /**
@@ -195,53 +313,7 @@ function createSessionsModule(deps) {
    * @returns {string|null} - Primary topic or null
    */
   function getSessionTopic(sessionId) {
-    if (!sessionId) return null;
-    try {
-      const transcriptPath = findTranscriptPath(sessionId);
-      if (!transcriptPath) return null;
-
-      // Read first 50KB of transcript (enough for topic detection, fast)
-      const fd = fs.openSync(transcriptPath, "r");
-      const buffer = Buffer.alloc(50000);
-      const bytesRead = fs.readSync(fd, buffer, 0, 50000, 0);
-      fs.closeSync(fd);
-
-      if (bytesRead === 0) return null;
-
-      const content = buffer.toString("utf8", 0, bytesRead);
-      const lines = content.split("\n").filter((l) => l.trim());
-
-      // Extract text from messages
-      // Transcript format: {type: "message", message: {role: "user"|"assistant", content: [...]}}
-      let textSamples = [];
-      for (const line of lines.slice(0, 30)) {
-        // First 30 entries
-        try {
-          const entry = JSON.parse(line);
-          if (entry.type === "message" && entry.message?.content) {
-            const msgContent = entry.message.content;
-            if (Array.isArray(msgContent)) {
-              msgContent.forEach((c) => {
-                if (c.type === "text" && c.text) {
-                  textSamples.push(c.text.slice(0, 500));
-                }
-              });
-            } else if (typeof msgContent === "string") {
-              textSamples.push(msgContent.slice(0, 500));
-            }
-          }
-        } catch (e) {
-          /* skip malformed lines */
-        }
-      }
-
-      if (textSamples.length === 0) return null;
-
-      const topics = detectTopics(textSamples.join(" "));
-      return topics.length > 0 ? topics.slice(0, 2).join(", ") : null;
-    } catch (e) {
-      return null;
-    }
+    return getSessionMetadata(sessionId).topic;
   }
 
   // Helper to map a single session (extracted from getSessions)
@@ -262,9 +334,10 @@ function createSessionsModule(deps) {
     else if (s.key.includes(":cron:")) sessionType = "cron";
     else if (s.key === "agent:main:main") sessionType = "main";
 
-    const originator = getSessionOriginator(s.sessionId);
+    const metadata = getSessionMetadata(s.sessionId);
+    const originator = metadata.originator;
     const label = s.groupChannel || s.displayName || parseSessionLabel(s.key);
-    const topic = getSessionTopic(s.sessionId);
+    const topic = metadata.topic;
 
     const totalTokens = s.totalTokens || 0;
     const sessionAgeMinutes = Math.max(1, Math.min(minutesAgo, 24 * 60));

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -12,7 +12,8 @@ const TOKEN_RATES = {
 
 // Token usage cache with async background refresh
 let tokenUsageCache = { data: null, timestamp: 0, refreshing: false };
-const TOKEN_USAGE_CACHE_TTL = 30000; // 30 seconds
+const TOKEN_USAGE_CACHE_TTL = 300000; // 5 minutes
+let tokenUsageFileCache = new Map();
 
 // Reference to background refresh interval (set by startTokenUsageRefresh)
 let refreshInterval = null;
@@ -20,6 +21,42 @@ let refreshInterval = null;
 // Create empty usage bucket
 function emptyUsageBucket() {
   return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, requests: 0 };
+}
+
+function addUsageToBucket(bucket, usage) {
+  bucket.input += usage.input;
+  bucket.output += usage.output;
+  bucket.cacheRead += usage.cacheRead;
+  bucket.cacheWrite += usage.cacheWrite;
+  bucket.cost += usage.cost;
+  bucket.requests++;
+}
+
+function collectTokenUsageEvents(content, sevenDaysAgo) {
+  const events = [];
+  const lines = content.trim().split("\n");
+
+  for (const line of lines) {
+    if (!line) continue;
+    try {
+      const entry = JSON.parse(line);
+      const entryTime = entry.timestamp ? new Date(entry.timestamp).getTime() : 0;
+      if (entryTime < sevenDaysAgo || !entry.message?.usage) continue;
+      const u = entry.message.usage;
+      events.push({
+        time: entryTime,
+        input: u.input || 0,
+        output: u.output || 0,
+        cacheRead: u.cacheRead || 0,
+        cacheWrite: u.cacheWrite || 0,
+        cost: u.cost?.total || 0,
+      });
+    } catch (e) {
+      // Skip invalid lines
+    }
+  }
+
+  return events;
 }
 
 // Async token usage refresh - runs in background, doesn't block
@@ -42,7 +79,9 @@ async function refreshTokenUsageAsync(getOpenClawDir) {
     const usage3d = emptyUsageBucket();
     const usage7d = emptyUsageBucket();
 
-    // Process files in batches to avoid overwhelming the system
+    // Process files in batches to avoid overwhelming the system. Cache parsed usage
+    // events by file mtime/size so routine refreshes do not re-parse every JSONL line.
+    const seenFiles = new Set();
     const batchSize = 50;
     for (let i = 0; i < jsonlFiles.length; i += batchSize) {
       const batch = jsonlFiles.slice(i, i + batchSize);
@@ -50,68 +89,49 @@ async function refreshTokenUsageAsync(getOpenClawDir) {
       await Promise.all(
         batch.map(async (file) => {
           const filePath = path.join(sessionsDir, file);
+          seenFiles.add(filePath);
+
           try {
             const stat = await fs.promises.stat(filePath);
             // Skip files not modified in the last 7 days
-            if (stat.mtimeMs < sevenDaysAgo) return;
+            if (stat.mtimeMs < sevenDaysAgo) {
+              tokenUsageFileCache.delete(filePath);
+              return;
+            }
 
-            const content = await fs.promises.readFile(filePath, "utf8");
-            const lines = content.trim().split("\n");
+            const cached = tokenUsageFileCache.get(filePath);
+            let events = cached?.events;
 
-            for (const line of lines) {
-              if (!line) continue;
-              try {
-                const entry = JSON.parse(line);
-                const entryTime = entry.timestamp ? new Date(entry.timestamp).getTime() : 0;
+            if (!cached || cached.mtimeMs !== stat.mtimeMs || cached.size !== stat.size) {
+              const content = await fs.promises.readFile(filePath, "utf8");
+              events = collectTokenUsageEvents(content, sevenDaysAgo);
+              tokenUsageFileCache.set(filePath, {
+                mtimeMs: stat.mtimeMs,
+                size: stat.size,
+                events,
+              });
+            }
 
-                // Skip entries older than 7 days
-                if (entryTime < sevenDaysAgo) continue;
-
-                if (entry.message?.usage) {
-                  const u = entry.message.usage;
-                  const input = u.input || 0;
-                  const output = u.output || 0;
-                  const cacheRead = u.cacheRead || 0;
-                  const cacheWrite = u.cacheWrite || 0;
-                  const cost = u.cost?.total || 0;
-
-                  // Add to appropriate buckets (cumulative - 24h is subset of 3d is subset of 7d)
-                  if (entryTime >= oneDayAgo) {
-                    usage24h.input += input;
-                    usage24h.output += output;
-                    usage24h.cacheRead += cacheRead;
-                    usage24h.cacheWrite += cacheWrite;
-                    usage24h.cost += cost;
-                    usage24h.requests++;
-                  }
-                  if (entryTime >= threeDaysAgo) {
-                    usage3d.input += input;
-                    usage3d.output += output;
-                    usage3d.cacheRead += cacheRead;
-                    usage3d.cacheWrite += cacheWrite;
-                    usage3d.cost += cost;
-                    usage3d.requests++;
-                  }
-                  // Always add to 7d (already filtered above)
-                  usage7d.input += input;
-                  usage7d.output += output;
-                  usage7d.cacheRead += cacheRead;
-                  usage7d.cacheWrite += cacheWrite;
-                  usage7d.cost += cost;
-                  usage7d.requests++;
-                }
-              } catch (e) {
-                // Skip invalid lines
-              }
+            for (const event of events) {
+              // Re-apply moving windows on every refresh without re-parsing JSON.
+              if (event.time < sevenDaysAgo) continue;
+              if (event.time >= oneDayAgo) addUsageToBucket(usage24h, event);
+              if (event.time >= threeDaysAgo) addUsageToBucket(usage3d, event);
+              addUsageToBucket(usage7d, event);
             }
           } catch (e) {
             // Skip unreadable files
+            tokenUsageFileCache.delete(filePath);
           }
         }),
       );
 
       // Yield to event loop between batches
       await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    for (const filePath of tokenUsageFileCache.keys()) {
+      if (!seenFiles.has(filePath)) tokenUsageFileCache.delete(filePath);
     }
 
     // Helper to finalize bucket with computed fields
@@ -448,6 +468,7 @@ function startTokenUsageRefresh(getOpenClawDir) {
 module.exports = {
   TOKEN_RATES,
   emptyUsageBucket,
+  collectTokenUsageEvents,
   refreshTokenUsageAsync,
   getDailyTokenUsage,
   calculateCostForBucket,

--- a/tests/sessions.test.js
+++ b/tests/sessions.test.js
@@ -1,0 +1,76 @@
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const { createSessionsModule } = require("../src/sessions");
+
+const SESSION_ID = "11111111-2222-3333-4444-555555555555";
+
+function makeModule(openclawDir) {
+  return createSessionsModule({
+    getOpenClawDir: () => openclawDir,
+    getOperatorBySlackId: () => null,
+    runOpenClaw: () => "",
+    runOpenClawAsync: async () => "",
+    extractJSON: () => null,
+  });
+}
+
+describe("sessions module", () => {
+  let tmpDir;
+  let sessionsDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "command-center-sessions-"));
+    sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fs.mkdirSync(sessionsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("finds topic-suffixed transcripts without requiring an exact transcript file", () => {
+    const suffixed = path.join(sessionsDir, `${SESSION_ID}-topic-20260721.jsonl`);
+    fs.writeFileSync(suffixed, "{}\n");
+
+    const sessions = makeModule(tmpDir);
+
+    assert.strictEqual(sessions.findTranscriptPath(SESSION_ID), suffixed);
+  });
+
+  it("prefers an exact transcript over a suffixed fallback", () => {
+    const suffixed = path.join(sessionsDir, `${SESSION_ID}-topic-20260721.jsonl`);
+    const exact = path.join(sessionsDir, `${SESSION_ID}.jsonl`);
+    fs.writeFileSync(suffixed, "{}\n");
+    fs.writeFileSync(exact, "{}\n");
+
+    const sessions = makeModule(tmpDir);
+
+    assert.strictEqual(sessions.findTranscriptPath(SESSION_ID), exact);
+  });
+
+  it("notices a newly-created exact transcript without rebuilding the fallback index", () => {
+    const suffixed = path.join(sessionsDir, `${SESSION_ID}-topic-20260721.jsonl`);
+    const exact = path.join(sessionsDir, `${SESSION_ID}.jsonl`);
+    fs.writeFileSync(suffixed, "{}\n");
+
+    const sessions = makeModule(tmpDir);
+
+    assert.strictEqual(sessions.findTranscriptPath(SESSION_ID), suffixed);
+
+    fs.writeFileSync(exact, "{}\n");
+
+    assert.strictEqual(sessions.findTranscriptPath(SESSION_ID), exact);
+  });
+
+  it("ignores deleted transcript markers when indexing fallbacks", () => {
+    const deleted = path.join(sessionsDir, `${SESSION_ID}-topic-20260721.deleted.jsonl`);
+    fs.writeFileSync(deleted, "{}\n");
+
+    const sessions = makeModule(tmpDir);
+
+    assert.strictEqual(sessions.findTranscriptPath(SESSION_ID), null);
+  });
+});

--- a/tests/tokens.test.js
+++ b/tests/tokens.test.js
@@ -1,6 +1,11 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
-const { TOKEN_RATES, emptyUsageBucket, calculateCostForBucket } = require("../src/tokens");
+const {
+  TOKEN_RATES,
+  emptyUsageBucket,
+  collectTokenUsageEvents,
+  calculateCostForBucket,
+} = require("../src/tokens");
 
 describe("tokens module", () => {
   describe("TOKEN_RATES", () => {
@@ -38,6 +43,45 @@ describe("tokens module", () => {
       assert.notStrictEqual(a, b);
       a.input = 100;
       assert.strictEqual(b.input, 0);
+    });
+  });
+
+  describe("collectTokenUsageEvents()", () => {
+    it("extracts usage events from recent JSONL entries", () => {
+      const now = Date.now();
+      const timestamp = new Date(now).toISOString();
+      const content = [
+        JSON.stringify({
+          timestamp,
+          message: {
+            usage: {
+              input: 100,
+              output: 20,
+              cacheRead: 10,
+              cacheWrite: 5,
+              cost: { total: 0.01 },
+            },
+          },
+        }),
+        "not-json",
+        JSON.stringify({
+          timestamp: new Date(now - 10_000).toISOString(),
+          message: {},
+        }),
+      ].join("\n");
+
+      const events = collectTokenUsageEvents(content, now - 60_000);
+
+      assert.deepStrictEqual(events, [
+        {
+          time: Date.parse(timestamp),
+          input: 100,
+          output: 20,
+          cacheRead: 10,
+          cacheWrite: 5,
+          cost: 0.01,
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary
- add a short-lived transcript path index for session transcript lookups
- preserve exact transcript preference while supporting topic-suffixed fallback files
- add regression coverage for suffixed fallback, exact preference, and deleted marker exclusion

## Validation
- npm test
- npm run lint (0 errors; existing warnings remain)
- npm run build
- live dashboard LaunchAgents restarted and verified healthy; CPU settled to 0.0% after warm-up on ports 3333 and 1333